### PR TITLE
Document how to install archive storybook with peer deps

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -10,10 +10,21 @@ Additionally, the archives you create during each test run can be viewed in a St
 
 ## Installation
 
-Get started by installing the archiver package, and the archive storybook:
+Get started by installing the archiver package, and the archive storybook.
+
+### As a new installation of Storybook
+
+If you aren't yet using Storybook in your project, install with:
 
 ```bash
-yarn add --dev @chromaui/test-archiver @chromaui/archive-storybook
+yarn add --dev @chromaui/test-archiver @chromaui/archive-storybook @storybook/cli @storybook/addon-essentials @storybook/server-webpack5
+```
+
+If you are already using Storybook, install as a second Storybook with:
+
+```bash
+# <version> here should be the version you are using for your other Storybook packages
+yarn add --dev @chromaui/test-archiver @chromaui/archive-storybook @storybook/server-webpack5@<version>
 ```
 
 ## Configuration

--- a/Documentation.md
+++ b/Documentation.md
@@ -17,7 +17,7 @@ Get started by installing the archiver package, and the archive storybook.
 If you aren't yet using Storybook in your project, install with:
 
 ```bash
-yarn add --dev @chromaui/test-archiver @chromaui/archive-storybook @storybook/cli @storybook/addon-essentials @storybook/server-webpack5
+yarn add --dev @chromaui/test-archiver @chromaui/archive-storybook @storybook/cli @storybook/addon-essentials @storybook/server-webpack5 react react-dom
 ```
 
 If you are already using Storybook, install as a second Storybook with:


### PR DESCRIPTION
Issue: https://linear.app/chromaui/issue/AP-3307/archive-storybook-contains-fixed-70x-version-of-storybook

## What Changed

Document how to install the package now `@chromaui/archive-storybook` has peer deps.

## How to test

See [PR](https://github.com/chromaui/archive-storybook/pull/3)

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [x] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.13--canary.6.5956cf8.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/test-archiver@0.0.13--canary.6.5956cf8.0
  # or 
  yarn add @chromaui/test-archiver@0.0.13--canary.6.5956cf8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
