### PR TITLE
Skip over CDP errors, but record to an error log

### DIFF
--- a/src/resource-archive/index.test.ts
+++ b/src/resource-archive/index.test.ts
@@ -87,9 +87,11 @@ function expectArchiveContainsPath(archive: ResourceArchive, path: string) {
   // Expect the content to match the archive's content, unless it's dynamic
   if (typeof expectedContent !== 'function') {
     const expectedBase64 = Buffer.from(expectedContent).toString('base64');
-    const actualBase64 = archive[pathUrl.toString()].body.toString('base64');
-
-    expect(actualBase64).toEqual(expectedBase64);
+    const response = archive[pathUrl.toString()];
+    if ('error' in response) {
+      throw new Error(`Response to ${path} should not be an error`);
+    }
+    expect(response.body.toString('base64')).toEqual(expectedBase64);
   }
 }
 


### PR DESCRIPTION
## What Changed

It seems various `client.send()` calls fail in circumstances we don't fully understand (e.g https://github.com/chromaui/chromatic/actions/runs/5618208830/attempts/1, and various customer reported issues).

It may be OK to ignore these errors -- in this PR, we skip over but record them to an `errors.log`. If resources are missing that are needed, we can refer to this log to see at what point the resource archiving failed.

## How to test

I'm not sure how to reproduce the problem, but running the canary against a real project to make sure it still works is a good idea.

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
