### PR TITLE
Use GH token for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Prepare repository
         run: git fetch --unshallow --tags
@@ -22,7 +24,7 @@ jobs:
 
       - name: Create Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           yarn release


### PR DESCRIPTION
Need to use a token with extended permission to allow pushing directly to `main` on releases.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.18--canary.9.80be68b.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/test-archiver@0.0.18--canary.9.80be68b.0
  # or 
  yarn add @chromaui/test-archiver@0.0.18--canary.9.80be68b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
