### PR TITLE
Respect viewport set via Playwright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build-storybook.log
 .env
 .cache
 yarn-error.log
+
+test-archives

--- a/Documentation.md
+++ b/Documentation.md
@@ -148,6 +148,7 @@ First run the E2E tests to generate the latest results
 ```bash
 yarn playwright test # or similar
 ```
+
 > The `--headed` flag displays your tests in the browser as they run, which can be another helpful tool for debugging.
 
 Then you can run the archive storybook with the `archive-storybook` command, and visit it like any other Storybook:

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@testing-library/react": "^12.0.0",
     "@testing-library/user-event": "^13.2.1",
     "@types/express": "^4.17.17",
+    "@types/fs-extra": "^11.0.1",
     "@types/jest": "^27.0.3",
     "@types/node": "^16.4.1",
     "auto": "^10.3.0",

--- a/src/playwright-api/makeTest.ts
+++ b/src/playwright-api/makeTest.ts
@@ -37,7 +37,9 @@ export const makeTest = (base: TestType<any, any>) =>
             .map(({ name, body }) => [name, body])
         ) as Record<string, Buffer>;
 
-        await writeTestResult(testInfo.title, snapshots, resourceArchive);
+        const viewport = page.viewportSize()
+
+        await writeTestResult(testInfo.title, snapshots, resourceArchive, {viewport});
 
         trackComplete();
       },

--- a/src/playwright-api/makeTest.ts
+++ b/src/playwright-api/makeTest.ts
@@ -37,9 +37,9 @@ export const makeTest = (base: TestType<any, any>) =>
             .map(({ name, body }) => [name, body])
         ) as Record<string, Buffer>;
 
-        const viewport = page.viewportSize()
+        const viewport = page.viewportSize();
 
-        await writeTestResult(testInfo.title, snapshots, resourceArchive, {viewport});
+        await writeTestResult(testInfo.title, snapshots, resourceArchive, { viewport });
 
         trackComplete();
       },

--- a/src/write-archive/index.test.ts
+++ b/src/write-archive/index.test.ts
@@ -1,4 +1,5 @@
 import fs from 'fs-extra';
+import { resolve } from 'path';
 import { writeTestResult } from '.';
 
 jest.mock('fs-extra');
@@ -28,7 +29,7 @@ describe('writeTestResult', () => {
     expect(fs.outputFile).toHaveBeenCalledTimes(2);
     expect(fs.outputJson).toHaveBeenCalledTimes(1);
     expect(fs.outputJson).toHaveBeenCalledWith(
-      '/Users/thafryer/Desktop/test-archiver/test-archives/11-1-1999-12-00-00-am/test-story.stories.json',
+      resolve('./test-archives/11-1-1999-12-00-00-am/test-story.stories.json'),
       {
         stories: [
           {

--- a/src/write-archive/index.test.ts
+++ b/src/write-archive/index.test.ts
@@ -1,0 +1,46 @@
+import fs from 'fs-extra';
+import { writeTestResult } from '.';
+
+jest.mock('fs-extra');
+describe('writeTestResult', () => {
+  beforeEach(() => {
+    const mockedDate = new Date(1999, 10, 1);
+
+    jest.useFakeTimers('modern');
+    jest.setSystemTime(mockedDate);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+  it('successfully generates test results', async () => {
+    // @ts-expect-error Jest mock
+    fs.ensureDir.mockReturnValue(true);
+    await writeTestResult(
+      'Test Story',
+      { home: Buffer.from('Chromatic') },
+      { 'http://localhost:3000/home': { statusCode: 200, body: Buffer.from('Chromatic') } },
+      { viewport: { height: 480, width: 720 } }
+    );
+    expect(fs.ensureDir).toHaveBeenCalledTimes(2);
+    expect(fs.ensureSymlink).toHaveBeenCalledTimes(1);
+    expect(fs.remove).not.toHaveBeenCalled();
+    expect(fs.outputFile).toHaveBeenCalledTimes(2);
+    expect(fs.outputJson).toHaveBeenCalledTimes(1);
+    expect(fs.outputJson).toHaveBeenCalledWith(
+      '/Users/thafryer/Desktop/test-archiver/test-archives/11-1-1999-12-00-00-am/test-story.stories.json',
+      {
+        stories: [
+          {
+            name: 'home',
+            parameters: {
+              chromatic: { viewports: [720] },
+              server: { id: 'test-story-home.snapshot.json' },
+            },
+          },
+        ],
+        title: 'Test Story',
+      }
+    );
+  });
+});

--- a/src/write-archive/index.ts
+++ b/src/write-archive/index.ts
@@ -102,10 +102,7 @@ async function writeStoriesFile(
         server: { id: `${sanitize(title)}-${sanitize(name)}.snapshot.json` },
         chromatic: {
           modes: {
-            viewport: {
-              width: chromaticOptions.viewport.width,
-              height: chromaticOptions.viewport.height,
-            },
+            viewports: [chromaticOptions.viewport.width],
           },
         },
       },

--- a/src/write-archive/index.ts
+++ b/src/write-archive/index.ts
@@ -36,7 +36,8 @@ const archiveDir = join(resultsDir, 'archive');
 export async function writeTestResult(
   title: string,
   domSnapshots: Record<string, Buffer>,
-  archive: ResourceArchive
+  archive: ResourceArchive,
+  chromaticOptions: {viewport: {width: number, height: number}}
 ) {
   await ensureDir(outputDir);
   await ensureDir(resultsDir);
@@ -70,7 +71,7 @@ export async function writeTestResult(
     );
   });
 
-  await writeStoriesFile(join(resultsDir, `${sanitize(title)}.stories.json`), title, domSnapshots);
+  await writeStoriesFile(join(resultsDir, `${sanitize(title)}.stories.json`), title, domSnapshots, chromaticOptions);
 
   const errors = Object.entries(archive).filter(([, r]) => 'error' in r);
   if (errors.length > 0) {
@@ -84,7 +85,8 @@ export async function writeTestResult(
 async function writeStoriesFile(
   storiesFilename: string,
   title: string,
-  domSnapshots: Record<string, Buffer>
+  domSnapshots: Record<string, Buffer>,
+  chromaticOptions: {viewport: {width: number, height: number}} 
 ) {
   logger.log(`Writing ${storiesFilename}`);
   await outputJson(storiesFilename, {
@@ -93,6 +95,11 @@ async function writeStoriesFile(
       name,
       parameters: {
         server: { id: `${sanitize(title)}-${sanitize(name)}.snapshot.json` },
+        chromatic: {
+          modes: {
+            viewport: chromaticOptions.viewport
+          }
+        }
       },
     })),
   });

--- a/src/write-archive/index.ts
+++ b/src/write-archive/index.ts
@@ -101,9 +101,10 @@ async function writeStoriesFile(
       parameters: {
         server: { id: `${sanitize(title)}-${sanitize(name)}.snapshot.json` },
         chromatic: {
-          modes: {
-            viewport: chromaticOptions.viewport,
-          },
+          viewports: [chromaticOptions.viewport.width],
+          // modes: {
+          //   viewport: chromaticOptions.viewport.width,
+          // },
         },
       },
     })),

--- a/src/write-archive/index.ts
+++ b/src/write-archive/index.ts
@@ -101,10 +101,12 @@ async function writeStoriesFile(
       parameters: {
         server: { id: `${sanitize(title)}-${sanitize(name)}.snapshot.json` },
         chromatic: {
-          viewports: [chromaticOptions.viewport.width],
-          // modes: {
-          //   viewport: chromaticOptions.viewport.width,
-          // },
+          modes: {
+            viewport: {
+              width: chromaticOptions.viewport.width,
+              height: chromaticOptions.viewport.height,
+            },
+          },
         },
       },
     })),

--- a/src/write-archive/index.ts
+++ b/src/write-archive/index.ts
@@ -101,9 +101,7 @@ async function writeStoriesFile(
       parameters: {
         server: { id: `${sanitize(title)}-${sanitize(name)}.snapshot.json` },
         chromatic: {
-          modes: {
-            viewports: [chromaticOptions.viewport.width],
-          },
+          viewports: [chromaticOptions.viewport.width],
         },
       },
     })),

--- a/src/write-archive/index.ts
+++ b/src/write-archive/index.ts
@@ -37,7 +37,7 @@ export async function writeTestResult(
   title: string,
   domSnapshots: Record<string, Buffer>,
   archive: ResourceArchive,
-  chromaticOptions: {viewport: {width: number, height: number}}
+  chromaticOptions: { viewport: { width: number; height: number } }
 ) {
   await ensureDir(outputDir);
   await ensureDir(resultsDir);
@@ -71,7 +71,12 @@ export async function writeTestResult(
     );
   });
 
-  await writeStoriesFile(join(resultsDir, `${sanitize(title)}.stories.json`), title, domSnapshots, chromaticOptions);
+  await writeStoriesFile(
+    join(resultsDir, `${sanitize(title)}.stories.json`),
+    title,
+    domSnapshots,
+    chromaticOptions
+  );
 
   const errors = Object.entries(archive).filter(([, r]) => 'error' in r);
   if (errors.length > 0) {
@@ -86,7 +91,7 @@ async function writeStoriesFile(
   storiesFilename: string,
   title: string,
   domSnapshots: Record<string, Buffer>,
-  chromaticOptions: {viewport: {width: number, height: number}} 
+  chromaticOptions: { viewport: { width: number; height: number } }
 ) {
   logger.log(`Writing ${storiesFilename}`);
   await outputJson(storiesFilename, {
@@ -97,9 +102,9 @@ async function writeStoriesFile(
         server: { id: `${sanitize(title)}-${sanitize(name)}.snapshot.json` },
         chromatic: {
           modes: {
-            viewport: chromaticOptions.viewport
-          }
-        }
+            viewport: chromaticOptions.viewport,
+          },
+        },
       },
     })),
   });

--- a/src/write-archive/index.ts
+++ b/src/write-archive/index.ts
@@ -21,12 +21,6 @@ const { OUTPUT_DIR = './test-archives' } = process.env;
 const outputDir = resolve(OUTPUT_DIR);
 const latestDir = join(outputDir, 'latest');
 
-// We take the timestamp once when the file is first process and use this timestamp for every
-// result we write
-const timestamp = sanitize(new Date().toLocaleString());
-const resultsDir = join(outputDir, timestamp);
-const archiveDir = join(resultsDir, 'archive');
-
 // We write a collection of DOM snapshots and a resource archive in the following locations:
 // ./test-results/latest => ./test-results/<timestamp> (a symlink)
 // ./test-results/<timestamp>/<title>.stories.json
@@ -39,6 +33,12 @@ export async function writeTestResult(
   archive: ResourceArchive,
   chromaticOptions: { viewport: { width: number; height: number } }
 ) {
+  // We take the timestamp once when the file is first process and use this timestamp for every
+  // result we write
+  const timestamp = sanitize(new Date().toLocaleString());
+  const resultsDir = join(outputDir, timestamp);
+  const archiveDir = join(resultsDir, 'archive');
+
   await ensureDir(outputDir);
   await ensureDir(resultsDir);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1910,6 +1910,14 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/fs-extra@^11.0.1":
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-11.0.1.tgz#f542ec47810532a8a252127e6e105f487e0a6ea5"
+  integrity sha512-MxObHvNl4A69ofaTRU8DFqvgzzv8s9yRtaPPm5gud9HDNvpB3GPQFvNuTWAI59B9huVGV5jXYJwbCsmBsOGYWA==
+  dependencies:
+    "@types/jsonfile" "*"
+    "@types/node" "*"
+
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -1961,6 +1969,13 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
+"@types/jsonfile@*":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@types/jsonfile/-/jsonfile-6.1.1.tgz#ac84e9aefa74a2425a0fb3012bdea44f58970f1b"
+  integrity sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==
+  dependencies:
+    "@types/node" "*"
 
 "@types/mdast@^3.0.0":
   version "3.0.3"


### PR DESCRIPTION
Issue: #

## What Changed

<!-- Insert a description below. -->
The generated Stories.json file now includes viewport values, which allows viewports set via Playwright to be passed to the Chromatic Capture Cloud.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
1. Set a viewport in your e2e tests via the Playwright API.
2. Run a Build

## Change Type

<!-- Indicate the change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.19--canary.10.b280b3a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/test-archiver@0.0.19--canary.10.b280b3a.0
  # or 
  yarn add @chromaui/test-archiver@0.0.19--canary.10.b280b3a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
