### PR TITLE
Fix infinite loading for 307 and 308 response statuses

### DIFF
--- a/src/resource-archive/index.ts
+++ b/src/resource-archive/index.ts
@@ -114,7 +114,7 @@ class Watcher {
 
     // Pausing a response stage with a response
     if (responseStatusCode) {
-      if ([301, 302].includes(responseStatusCode)) {
+      if ([301, 302, 307, 308].includes(responseStatusCode)) {
         await this.clientSend(request, 'Fetch.continueRequest', {
           requestId,
           interceptResponse: true,


### PR DESCRIPTION
Issue: https://github.com/chromaui/test-archiver/issues/13

## What Changed

Applies the same behavior from 301 and 302 response status codes also for 307 and 308.

## How to test

See https://github.com/joshuajaco/playwright-chromatic-redirect-issue/blob/main/some.test.ts

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
