### PR TITLE
Wait for all resources to load before indicating Watcher is idle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,4 @@ import { makeTest } from './playwright-api/makeTest';
 export const test = makeTest(base);
 export { expect };
 
-export { takeSnapshot as takeArchive } from './playwright-api/takeSnapshot';
+export { takeArchive } from './playwright-api/takeArchive';

--- a/src/playwright-api/makeTest.ts
+++ b/src/playwright-api/makeTest.ts
@@ -1,7 +1,7 @@
 import type { TestType } from '@playwright/test';
 import { createResourceArchive } from '../resource-archive';
 import { writeTestResult } from '../write-archive';
-import { contentType, takeSnapshot } from './takeSnapshot';
+import { contentType, takeArchive } from './takeArchive';
 import { trackComplete, trackRun } from '../utils/analytics';
 
 // We do this slightly odd thing (makeTest) to avoid importing playwright multiple times when
@@ -27,7 +27,7 @@ export const makeTest = (base: TestType<any, any>) =>
         const completeArchive = await createResourceArchive(page);
         await use();
 
-        await takeSnapshot(page, testInfo);
+        await takeArchive(page, testInfo);
 
         const resourceArchive = await completeArchive();
 

--- a/src/playwright-api/takeArchive.ts
+++ b/src/playwright-api/takeArchive.ts
@@ -12,9 +12,9 @@ const rrweb = readFileSync(
 
 export const contentType = 'application/rrweb.snapshot+json';
 
-async function takeSnapshot(page: Page, testInfo: TestInfo): Promise<void>;
-async function takeSnapshot(page: Page, name: string, testInfo: TestInfo): Promise<void>;
-async function takeSnapshot(
+async function takeArchive(page: Page, testInfo: TestInfo): Promise<void>;
+async function takeArchive(page: Page, name: string, testInfo: TestInfo): Promise<void>;
+async function takeArchive(
   page: Page,
   nameOrTestInfo: string | TestInfo,
   maybeTestInfo?: TestInfo
@@ -44,4 +44,4 @@ async function takeSnapshot(
   testInfo.attach(name, { contentType, body: JSON.stringify(domSnapshot) });
 }
 
-export { takeSnapshot };
+export { takeArchive };

--- a/src/resource-archive/index.test.ts
+++ b/src/resource-archive/index.test.ts
@@ -108,6 +108,24 @@ describe('new', () => {
   });
 
   // eslint-disable-next-line jest/expect-expect
+  it('should respond with an exception if the network times out waiting for requests', async () => {
+    const complete = await createResourceArchive(page, 1);
+
+    await page.goto(baseUrl);
+
+    // eslint-disable-next-line jest/valid-expect-in-promise
+    complete()
+      .then(() => {
+        throw new Error('Test did not throw an exception');
+      })
+
+      .catch((e) => {
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(e).toEqual(new Error(`Global timeout of 1ms reached`));
+      });
+  });
+
+  // eslint-disable-next-line jest/expect-expect
   it('gathers basic resources used by the page', async () => {
     const complete = await createResourceArchive(page);
 


### PR DESCRIPTION
Issue: CAP-1082

## What Changed

This adds a set of promises to the `Watcher` class that represent network requests made by the client _prior_ to the archive being created. For each of the network requests, as long as it is not ignored (i.e. within the `baseUrl`), the promise will resolve when the network request resolves. Once all of these promises are resolved, OR when a 4s timer has expired, the `Watcher` will indicate it is idle.

## How to test

You can run the tests using `yarn test`. A new test was added with a large image that takes an amount of time to load. Alternatively, run the `test-archiver` after having linked a project that can utilize it with `yarn link`.
 
## Change Type

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch` - This should introduce no new behavior and instead should be backward compatible.
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.25--canary.16.982fd10.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/test-archiver@0.0.25--canary.16.982fd10.0
  # or 
  yarn add @chromaui/test-archiver@0.0.25--canary.16.982fd10.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
