### PR TITLE
Write archives to Playwright-created folder

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -199,4 +199,16 @@ chromatic:
 
 You can further configure things in the following way:
 
-- To specify a custom archive location, set the `CHROMATIC_ARCHIVE_LOCATION` environment variable, when starting the Storybook (or publishing it in on CI).
+- If a custom [output directory](https://playwright.dev/docs/api/class-testconfig#test-config-output-dir) is used in Playwright, set the `CHROMATIC_ARCHIVE_LOCATION` environment variable to the same location when running `build-archive-storybook` and `archive-storybook`.
+
+Example:
+
+```
+  // playwright config
+  export default defineConfig({
+    outputDir: 'my-playwright-results'
+  });
+
+  # command line
+  CHROMATIC_ARCHIVE_LOCATION=my-playwright-results yarn build-archive-storybook
+```

--- a/Documentation.md
+++ b/Documentation.md
@@ -199,4 +199,4 @@ chromatic:
 
 You can further configure things in the following way:
 
-- To override the archive location, set the `CHROMATIC_ARCHIVE_LOCATION` environment variable, both when running your Playwright tests and when starting the Storybook (or publishing it in on CI).
+- To specify a custom archive location, set the `CHROMATIC_ARCHIVE_LOCATION` environment variable, when starting the Storybook (or publishing it in on CI).

--- a/Documentation.md
+++ b/Documentation.md
@@ -199,7 +199,7 @@ chromatic:
 
 You can further configure things in the following way:
 
-- If a custom [output directory](https://playwright.dev/docs/api/class-testconfig#test-config-output-dir) is used in Playwright, set the `CHROMATIC_ARCHIVE_LOCATION` environment variable to the same location when running `build-archive-storybook` and `archive-storybook`.
+- If a custom [output directory](https://playwright.dev/docs/api/class-testconfig#test-config-output-dir) is used in Playwright, set the `CHROMATIC_ARCHIVE_LOCATION` environment variable to this location when running `build-archive-storybook` and `archive-storybook`.
 
 Example:
 

--- a/src/playwright-api/makeTest.ts
+++ b/src/playwright-api/makeTest.ts
@@ -39,7 +39,7 @@ export const makeTest = (base: TestType<any, any>) =>
 
         const viewport = page.viewportSize();
 
-        await writeTestResult(testInfo.title, snapshots, resourceArchive, { viewport });
+        await writeTestResult(testInfo, snapshots, resourceArchive, { viewport });
 
         trackComplete();
       },

--- a/src/write-archive/index.test.ts
+++ b/src/write-archive/index.test.ts
@@ -6,6 +6,9 @@ jest.mock('fs-extra');
 describe('writeTestResult', () => {
   beforeEach(() => {
     const mockedDate = new Date(1999, 10, 1);
+    fs.ensureDir.mockClear();
+    fs.outputFile.mockClear();
+    fs.outputJson.mockClear();
 
     jest.useFakeTimers('modern');
     jest.setSystemTime(mockedDate);
@@ -18,6 +21,7 @@ describe('writeTestResult', () => {
     // @ts-expect-error Jest mock
     fs.ensureDir.mockReturnValue(true);
     await writeTestResult(
+      // the default output directory in playwright
       { title: 'Test Story', outputDir: resolve('test-results/test-story-chromium') },
       { home: Buffer.from('Chromatic') },
       { 'http://localhost:3000/home': { statusCode: 200, body: Buffer.from('Chromatic') } },
@@ -28,6 +32,39 @@ describe('writeTestResult', () => {
     expect(fs.outputJson).toHaveBeenCalledTimes(1);
     expect(fs.outputJson).toHaveBeenCalledWith(
       resolve('./test-results/chromatic-archives/test-story.stories.json'),
+      {
+        stories: [
+          {
+            name: 'home',
+            parameters: {
+              chromatic: { viewports: [720] },
+              server: { id: 'test-story-home.snapshot.json' },
+            },
+          },
+        ],
+        title: 'Test Story',
+      }
+    );
+  });
+
+  it('stores archives in custom directory', async () => {
+    // @ts-expect-error Jest mock
+    fs.ensureDir.mockReturnValue(true);
+    await writeTestResult(
+      {
+        title: 'Test Story',
+        // simulates setting a custom output directory in Playwright
+        outputDir: resolve('some-custom-directory/directory/test-story-chromium'),
+      },
+      { home: Buffer.from('Chromatic') },
+      { 'http://localhost:3000/home': { statusCode: 200, body: Buffer.from('Chromatic') } },
+      { viewport: { height: 480, width: 720 } }
+    );
+    expect(fs.ensureDir).toHaveBeenCalledTimes(1);
+    expect(fs.outputFile).toHaveBeenCalledTimes(2);
+    expect(fs.outputJson).toHaveBeenCalledTimes(1);
+    expect(fs.outputJson).toHaveBeenCalledWith(
+      resolve('./some-custom-directory/directory/chromatic-archives/test-story.stories.json'),
       {
         stories: [
           {

--- a/src/write-archive/index.test.ts
+++ b/src/write-archive/index.test.ts
@@ -18,18 +18,16 @@ describe('writeTestResult', () => {
     // @ts-expect-error Jest mock
     fs.ensureDir.mockReturnValue(true);
     await writeTestResult(
-      'Test Story',
+      { title: 'Test Story', outputDir: resolve('test-results/test-story-chromium') },
       { home: Buffer.from('Chromatic') },
       { 'http://localhost:3000/home': { statusCode: 200, body: Buffer.from('Chromatic') } },
       { viewport: { height: 480, width: 720 } }
     );
-    expect(fs.ensureDir).toHaveBeenCalledTimes(2);
-    expect(fs.ensureSymlink).toHaveBeenCalledTimes(1);
-    expect(fs.remove).not.toHaveBeenCalled();
+    expect(fs.ensureDir).toHaveBeenCalledTimes(1);
     expect(fs.outputFile).toHaveBeenCalledTimes(2);
     expect(fs.outputJson).toHaveBeenCalledTimes(1);
     expect(fs.outputJson).toHaveBeenCalledWith(
-      resolve('./test-archives/11-1-1999-12-00-00-am/test-story.stories.json'),
+      resolve('./test-results/chromatic-archives/test-story.stories.json'),
       {
         stories: [
           {

--- a/src/write-archive/index.test.ts
+++ b/src/write-archive/index.test.ts
@@ -1,28 +1,22 @@
 import fs from 'fs-extra';
 import { resolve } from 'path';
+import type { TestInfo } from '@playwright/test';
 import { writeTestResult } from '.';
 
 jest.mock('fs-extra');
 describe('writeTestResult', () => {
   beforeEach(() => {
-    const mockedDate = new Date(1999, 10, 1);
     fs.ensureDir.mockClear();
     fs.outputFile.mockClear();
     fs.outputJson.mockClear();
-
-    jest.useFakeTimers('modern');
-    jest.setSystemTime(mockedDate);
   });
 
-  afterEach(() => {
-    jest.useRealTimers();
-  });
   it('successfully generates test results', async () => {
     // @ts-expect-error Jest mock
     fs.ensureDir.mockReturnValue(true);
     await writeTestResult(
       // the default output directory in playwright
-      { title: 'Test Story', outputDir: resolve('test-results/test-story-chromium') },
+      { title: 'Test Story', outputDir: resolve('test-results/test-story-chromium') } as TestInfo,
       { home: Buffer.from('Chromatic') },
       { 'http://localhost:3000/home': { statusCode: 200, body: Buffer.from('Chromatic') } },
       { viewport: { height: 480, width: 720 } }
@@ -55,7 +49,7 @@ describe('writeTestResult', () => {
         title: 'Test Story',
         // simulates setting a custom output directory in Playwright
         outputDir: resolve('some-custom-directory/directory/test-story-chromium'),
-      },
+      } as TestInfo,
       { home: Buffer.from('Chromatic') },
       { 'http://localhost:3000/home': { statusCode: 200, body: Buffer.from('Chromatic') } },
       { viewport: { height: 480, width: 720 } }

--- a/src/write-archive/index.ts
+++ b/src/write-archive/index.ts
@@ -1,5 +1,6 @@
 import { outputFile, ensureDir, outputJson } from 'fs-extra';
 import { join } from 'path';
+import type { TestInfo } from '@playwright/test';
 
 import type { ResourceArchive } from '../resource-archive';
 import { logger } from '../utils/logger';
@@ -23,7 +24,7 @@ export const sanitize = (string: string) => {
 // archive/<file>.<ext>
 
 export async function writeTestResult(
-  testInfo: any,
+  testInfo: TestInfo,
   domSnapshots: Record<string, Buffer>,
   archive: ResourceArchive,
   chromaticOptions: { viewport: { width: number; height: number } }


### PR DESCRIPTION
## What Changed

<!-- Insert a description below. -->

Writes archives to the playwright-created directory (`test-results` by default,  the value of `outputDir` if specified in the `playwright.config.js`). 

Previously we wrote to the `test-archives` storybook, putting tests in a timestamped folder and symlinking the latest timestamped folder to `/latest`. However, if tests didn't all run at the same time, they'd end up in different timestamped folders, thus `/latest` wouldn't have all of the archives (and thus the storybook wouldn't be complete).

Since the playwright-managed `test-results` directory is destroyed at the beginning of each test run, we can be sure any archives written there are from the same run.

We put these archives in `test-results/chromatic-archives` (so the archives aren't rummaged in whatever playwright is creating/reading from at the `test-results` level).

**_This needs to release at the same time as the corresponding `archive-storybook` [change](https://github.com/chromaui/archive-storybook/pull/6)._**

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->

On an e2e project depending on this library:
1. Create multiple tests in multiple files
1. Run `yarn playwright test`
2. Verify that the archives are written to `test-results/chromatic-archives` directory 
3. Verify that that folder contains the archives/DOM representations of all the tests
4. In `playwright.config.js`, tell Playwright to write test results to a custom directory (`outputDir` [option](https://playwright.dev/docs/api/class-testconfig#test-config-output-dir))
5. Run `yarn playwright test`
6. Verify that the archives are written to this custom directory instead

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.21--canary.17.ec4768b.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/test-archiver@0.0.21--canary.17.ec4768b.0
  # or 
  yarn add @chromaui/test-archiver@0.0.21--canary.17.ec4768b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
