### PR TITLE
Allow Chromatic configuration options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export const test = makeTest(base);
 export { expect };
 
 export { takeArchive } from './playwright-api/takeArchive';
+export type { ChromaticConfig } from './types';

--- a/src/playwright-api/makeTest.ts
+++ b/src/playwright-api/makeTest.ts
@@ -5,7 +5,7 @@ import type {
   PlaywrightWorkerArgs,
   PlaywrightWorkerOptions,
 } from '@playwright/test';
-import type { ChromaticConfig, ChromaticStorybookParameters } from 'src/types';
+import type { ChromaticConfig, ChromaticStorybookParameters } from '../types';
 import { createResourceArchive } from '../resource-archive';
 import { writeTestResult } from '../write-archive';
 import { contentType, takeArchive } from './takeArchive';

--- a/src/playwright-api/makeTest.ts
+++ b/src/playwright-api/makeTest.ts
@@ -53,7 +53,7 @@ export const makeTest = (
         await use();
 
         let sourceMap;
-        const takeAutoCapture = !chromatic.disableE2EAutoCapture;
+        const takeAutoCapture = !chromatic.disableAutoCapture;
         if (takeAutoCapture) {
           sourceMap = await takeArchive(page, testInfo);
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,23 @@
 export interface ChromaticConfig {
+  // https://www.chromatic.com/docs/delay/
   delay?: number;
+
+  // https://www.chromatic.com/docs/threshold/#anti-aliasing
   diffIncludeAntiAliasing?: boolean;
+
+  // https://www.chromatic.com/docs/threshold/#setting-the-threshold
   diffThreshold?: number;
+
+  // Disable the capture that happens automatically at the end of a test when using the Chromatic test fixture
   disableAutoCapture?: boolean;
+
+  // https://www.chromatic.com/docs/media-features/#test-high-contrast-color-schemes
   forcedColors?: string;
+
+  // https://www.chromatic.com/docs/animations/#css-animations
   pauseAnimationAtEnd?: boolean;
+
+  // https://www.chromatic.com/docs/media-features/#verify-reduced-motion-animations
   prefersReducedMotion?: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,5 +3,12 @@ export interface ChromaticConfig {
 }
 
 export interface ChromaticParameters {
+  diffIncludeAntiAliasing?: boolean;
+  diffThreshold?: number;
   disableE2EAutoCapture?: boolean;
+  pauseAnimationAtEnd?: boolean;
+}
+
+export interface ChromaticStorybookParameters extends ChromaticParameters {
+  viewports: number[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,7 @@
+export interface ChromaticConfig {
+  chromatic: ChromaticParameters;
+}
+
+export interface ChromaticParameters {
+  disableE2EAutoCapture?: boolean;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,13 @@
 export interface ChromaticConfig {
-  chromatic: ChromaticParameters;
-}
-
-export interface ChromaticParameters {
+  delay?: number;
   diffIncludeAntiAliasing?: boolean;
   diffThreshold?: number;
   disableAutoCapture?: boolean;
+  forcedColors?: string;
   pauseAnimationAtEnd?: boolean;
+  prefersReducedMotion?: string;
 }
 
-export interface ChromaticStorybookParameters extends ChromaticParameters {
+export interface ChromaticStorybookParameters extends Omit<ChromaticConfig, 'disableAutoCapture'> {
   viewports: number[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export interface ChromaticConfig {
 export interface ChromaticParameters {
   diffIncludeAntiAliasing?: boolean;
   diffThreshold?: number;
-  disableE2EAutoCapture?: boolean;
+  disableAutoCapture?: boolean;
   pauseAnimationAtEnd?: boolean;
 }
 

--- a/src/write-archive/index.test.ts
+++ b/src/write-archive/index.test.ts
@@ -84,7 +84,7 @@ describe('writeTestResult', () => {
           body: Buffer.from(JSON.stringify(storyJson)),
         },
       },
-      { viewport: { height: 480, width: 720 } },
+      { viewports: [720] },
       sourceMapping
     );
 

--- a/src/write-archive/index.test.ts
+++ b/src/write-archive/index.test.ts
@@ -19,7 +19,7 @@ describe('writeTestResult', () => {
       { title: 'Test Story', outputDir: resolve('test-results/test-story-chromium') } as TestInfo,
       { home: Buffer.from('Chromatic') },
       { 'http://localhost:3000/home': { statusCode: 200, body: Buffer.from('Chromatic') } },
-      { viewport: { height: 480, width: 720 } },
+      { diffThreshold: 5, viewports: [720] },
       new Map<string, string>()
     );
     expect(fs.ensureDir).toHaveBeenCalledTimes(1);
@@ -32,7 +32,7 @@ describe('writeTestResult', () => {
           {
             name: 'home',
             parameters: {
-              chromatic: { viewports: [720] },
+              chromatic: { diffThreshold: 5, viewports: [720] },
               server: { id: 'test-story-home.snapshot.json' },
             },
           },
@@ -119,7 +119,7 @@ describe('writeTestResult', () => {
       } as TestInfo,
       { home: Buffer.from('Chromatic') },
       { 'http://localhost:3000/home': { statusCode: 200, body: Buffer.from('Chromatic') } },
-      { viewport: { height: 480, width: 720 } },
+      { viewports: [720] },
       new Map<string, string>()
     );
     expect(fs.ensureDir).toHaveBeenCalledTimes(1);

--- a/src/write-archive/index.test.ts
+++ b/src/write-archive/index.test.ts
@@ -19,7 +19,11 @@ describe('writeTestResult', () => {
       { title: 'Test Story', outputDir: resolve('test-results/test-story-chromium') } as TestInfo,
       { home: Buffer.from('Chromatic') },
       { 'http://localhost:3000/home': { statusCode: 200, body: Buffer.from('Chromatic') } },
-      { diffThreshold: 5, viewports: [720] },
+      {
+        diffThreshold: 5,
+        pauseAnimationAtEnd: true,
+        viewports: [720],
+      },
       new Map<string, string>()
     );
     expect(fs.ensureDir).toHaveBeenCalledTimes(1);
@@ -32,7 +36,7 @@ describe('writeTestResult', () => {
           {
             name: 'home',
             parameters: {
-              chromatic: { diffThreshold: 5, viewports: [720] },
+              chromatic: { diffThreshold: 5, pauseAnimationAtEnd: true, viewports: [720] },
               server: { id: 'test-story-home.snapshot.json' },
             },
           },

--- a/src/write-archive/index.ts
+++ b/src/write-archive/index.ts
@@ -2,7 +2,7 @@ import { outputFile, ensureDir, outputJson } from 'fs-extra';
 import { join } from 'path';
 import type { TestInfo } from '@playwright/test';
 import type { elementNode } from '@chromaui/rrweb-snapshot';
-
+import type { ChromaticStorybookParameters } from '../types';
 import type { ResourceArchive } from '../resource-archive';
 import { logger } from '../utils/logger';
 
@@ -28,7 +28,7 @@ export async function writeTestResult(
   testInfo: TestInfo,
   domSnapshots: Record<string, Buffer>,
   archive: ResourceArchive,
-  chromaticOptions: { viewport: { width: number; height: number } },
+  chromaticStorybookParams: ChromaticStorybookParameters,
   sourceMap: Map<string, string>
 ) {
   const { title, outputDir } = testInfo;
@@ -72,7 +72,7 @@ export async function writeTestResult(
     join(finalOutputDir, `${sanitize(title)}.stories.json`),
     title,
     domSnapshots,
-    chromaticOptions
+    chromaticStorybookParams
   );
 
   const errors = Object.entries(archive).filter(([, r]) => 'error' in r);
@@ -137,7 +137,7 @@ async function writeStoriesFile(
   storiesFilename: string,
   title: string,
   domSnapshots: Record<string, Buffer>,
-  chromaticOptions: { viewport: { width: number; height: number } }
+  chromaticStorybookParams: ChromaticStorybookParameters
 ) {
   logger.log(`Writing ${storiesFilename}`);
   await outputJson(storiesFilename, {
@@ -147,7 +147,7 @@ async function writeStoriesFile(
       parameters: {
         server: { id: `${sanitize(title)}-${sanitize(name)}.snapshot.json` },
         chromatic: {
-          viewports: [chromaticOptions.viewport.width],
+          ...chromaticStorybookParams,
         },
       },
     })),


### PR DESCRIPTION
## What Changed

<!-- Insert a description below. -->
Allow for [Chromatic options](https://github.com/chromaui/test-archiver/blob/b767c4e28f716bfdd4155768b7abfd67f574df7f/src/types.ts#L1-L9), including disabling the auto snapshot, and Chromatic options passed into the stories parameters.

Top-level config options can be defined in the playwright config file [like this](https://github.com/tevanoff/chromatic-e2e-issues/blob/05ec3728c58ddae1329059b14606ed000d7e6f6e/playwright.config.ts#L4-L8).

Options can be overridden at the test-level [like this](https://github.com/tevanoff/chromatic-e2e-issues/blob/05ec3728c58ddae1329059b14606ed000d7e6f6e/chromatic-params.test.ts#L16).

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
* Use this canary version to configure a test project
* Or, pull down [this branch](https://github.com/tevanoff/chromatic-e2e-issues/tree/chromatic-params) and run `yarn playwright test chromatic-params.test.ts`

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.28--canary.22.03eecbf.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/test-archiver@0.0.28--canary.22.03eecbf.0
  # or 
  yarn add @chromaui/test-archiver@0.0.28--canary.22.03eecbf.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
