### PR TITLE
Consolidate all asset path Playwright testing into one page

### DIFF
--- a/__playwright-tests__/archiving-assets.spec.ts
+++ b/__playwright-tests__/archiving-assets.spec.ts
@@ -1,13 +1,5 @@
 import { test, expect } from '../src';
 
-test('file names are shortened to a valid length for the file system', async ({ page }) => {
-  await page.goto('/toolong');
-});
-
-test('file names will not collide with a directory of the same name', async ({ page }) => {
-  await page.goto('/conflict');
-});
-
-test('query strings are encoded into the file name', async ({ page }) => {
-  await page.goto('/assets-with-queryparams');
+test('asset paths', async ({ page }) => {
+  await page.goto('/asset-paths');
 });

--- a/__playwright-tests__/fixtures/asset-paths.html
+++ b/__playwright-tests__/fixtures/asset-paths.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+  <head>
+    <script src="https://cdn.tailwindcss.com"></script>
+
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <div class="image-container flex flex-wrap">
+      <div><img src="/img?url=fixtures/blue.png"/></div>
+      <div><img src="/img?url=fixtures/purple.png"/></div>
+      <div><img src="/img?url=fixtures/pink.png"/></div>
+      <div><img src="/img"/></div>
+      <div><img src="/img/another"/></div>
+      <div><img src="/blahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahb"></div>
+      <div><img src="https://www.chromatic.com/emails/icon-chroma-64x64.png?test=query"/></div>
+      <div class="with-background-img"></div>
+      <div class="with-external-background-img"></div>
+      <div class="with-rewritten-background-img"></div>
+    </div>
+  </body>
+</html>

--- a/__playwright-tests__/fixtures/styles.css
+++ b/__playwright-tests__/fixtures/styles.css
@@ -1,0 +1,18 @@
+.with-background-img {
+  background-image: url('/background-img.png');
+}
+
+.with-external-background-img {
+  background-image: url('https://www.chromatic.com/emails/icon-chroma-64x64.png?test=query');
+}
+
+.with-rewritten-background-img {
+  background-image: url('/img?url=fixtures/purple.png');
+}
+
+.image-container > div {
+  height: 200px;
+  width: 200px;
+  margin: 5px;
+  border: 1px solid black;
+}

--- a/__playwright-tests__/server.js
+++ b/__playwright-tests__/server.js
@@ -8,14 +8,20 @@ const port = 3000;
 const htmlIntro = `<!doctype html><html>`;
 const htmlOutro = `</html>`;
 
+// Pages
+
 app.get('/', (req, res) => {
-  res.send(`${htmlIntro}<body>testing 1 2 3</body>${htmlOutro}`);
+  res.send(`${htmlIntro}<body>Testing</body>${htmlOutro}`);
 });
 
-app.get('/toolong', (req, res) => {
-  res.send(
-    `${htmlIntro}<body><img src="/blahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahbblahblahblahblahblahblahblahblahblahblahb"></body>${htmlOutro}`
-  );
+app.get('/asset-paths', (req, res) => {
+  res.sendFile(path.join(__dirname, 'fixtures/asset-paths.html'));
+});
+
+// Assets
+
+app.get('/styles.css', (req, res) => {
+  res.sendFile(path.join(__dirname, 'fixtures/styles.css'));
 });
 
 app.get(
@@ -24,16 +30,6 @@ app.get(
     res.sendFile(path.join(__dirname, 'fixtures/blue.png'));
   }
 );
-
-app.get('/conflict', (req, res) => {
-  res.send(`${htmlIntro}<body><img src="/img"></img><img src="/img/another"></body>${htmlOutro}`);
-});
-
-app.get('/assets-with-queryparams', (req, res) => {
-  res.send(
-    `${htmlIntro}<body><img width="200" src="/img?url=fixtures/blue.png"/><img width="200" src="/img?url=fixtures/purple.png"/><img width="200" src="/img?url=fixtures/pink.png"/></body>${htmlOutro}`
-  );
-});
 
 app.get('/img', (req, res) => {
   if (req.query.url) {
@@ -45,6 +41,10 @@ app.get('/img', (req, res) => {
 
 app.get('/img/another', (req, res) => {
   res.sendFile(path.join(__dirname, 'fixtures/pink.png'));
+});
+
+app.get('/background-img.png', (req, res) => {
+  res.sendFile(path.join(__dirname, 'fixtures/purple.png'));
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
Issue: #

## What Changed

<!-- Insert a description below. -->
Moved all of the different asset path tests into one page and test.

The archive Storybook does highlight one bug that we currently have where we're not properly rewriting asset paths in CSS files.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
Look at the Chromatic build for this.

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
