### PR TITLE
Only archive assets fetched via GET

### DIFF
--- a/__playwright-tests__/fixtures/forms.html
+++ b/__playwright-tests__/fixtures/forms.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <script src="https://cdn.tailwindcss.com"></script>
+
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body class="page">
+    <form id="form-success" method="post" action="/form-success" class="mb-5">
+      <input type="submit" value="Click me" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" />
+    </form>
+  </body>
+</html>

--- a/__playwright-tests__/fixtures/styles.css
+++ b/__playwright-tests__/fixtures/styles.css
@@ -1,3 +1,8 @@
+body.page {
+  padding: 20px;
+  background-color: ghostwhite;
+}
+
 .with-background-img {
   background-image: url('/background-img.png');
 }

--- a/__playwright-tests__/forms.spec.ts
+++ b/__playwright-tests__/forms.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '../src';
+
+test('form submits succesfully', async ({ page }) => {
+  test.setTimeout(2000);
+  await page.goto('/forms');
+  await page.locator('#form-success input[type="submit"]').click();
+  await expect(page.getByText('OK!')).toBeVisible();
+});

--- a/__playwright-tests__/server.js
+++ b/__playwright-tests__/server.js
@@ -18,6 +18,22 @@ app.get('/asset-paths', (req, res) => {
   res.sendFile(path.join(__dirname, 'fixtures/asset-paths.html'));
 });
 
+app.get('/forms', (req, res) => {
+  res.sendFile(path.join(__dirname, 'fixtures/forms.html'));
+});
+
+// Send a redirect to the GET handler with the same path to ensure we're not caching POST responses and serving
+// it instead of the real GET response.
+app.post('/form-success', (req, res) => {
+  res.send(
+    `${htmlIntro}<head><meta http-equiv="refresh" content="0; URL=/form-success" /></head><body></body>${htmlOutro}`
+  );
+});
+
+app.get('/form-success', (req, res) => {
+  res.send(`${htmlIntro}<body><p>OK!</p></body>${htmlOutro}`);
+});
+
 // Assets
 
 app.get('/styles.css', (req, res) => {

--- a/src/resource-archive/index.ts
+++ b/src/resource-archive/index.ts
@@ -117,6 +117,13 @@ class Watcher {
     responseErrorReason,
     responseHeaders,
   }: Protocol.Fetch.requestPausedPayload) {
+    // We only need to capture assets that will render when the DOM snapshot is rendered,
+    // so we only need to handle GET requests.
+    if (!request.method.match(/get/i)) {
+      await this.clientSend(request, 'Fetch.continueRequest', { requestId });
+      return;
+    }
+
     const requestUrl = new URL(request.url);
 
     this.firstUrl ??= requestUrl;


### PR DESCRIPTION
Issue: AP-3798

## What Changed

Only archive assets fetched via GET. 

This fixes a bug with our asset capturing where we cache a response and then return it whenever the same path is encountered again. 

That logic is fine when we're dealing with a static asset, but it's faulty when dealing with tests that may have some back and forth with an API.

For example, a test could invoke a `POST /things` to create a thing, and then wait for the UI to refresh with the new thing. But with a standard REST API, there could be another request to `GET /things` in order to fetch all the things to render. Currently, the asset watcher will match on `/things` and return the response for the `POST`, which will most definitely break the test.

**Reasoning**
We only need to capture assets that will be loaded when we take the DOM snapshot and render it in a browser. At that point, the javascript tags will have been modified so that they don't run. So the only requests being made will be GET requests from `src`, `href`, `url()`, etc markup elements.

## How to test

Run playwright tests, check Chromatic build.

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.35--canary.32.9eb328c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/test-archiver@0.0.35--canary.32.9eb328c.0
  # or 
  yarn add @chromaui/test-archiver@0.0.35--canary.32.9eb328c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
