### PR TITLE
Fix mapping of CSS URLs

### DIFF
--- a/__playwright-tests__/fixtures/asset-paths.html
+++ b/__playwright-tests__/fixtures/asset-paths.html
@@ -4,6 +4,12 @@
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="/styles.css" />
+
+    <style>
+      .with-rewritten-background-img-inline {
+        background-image: url('/img?url=fixtures/blue.png');
+      }
+    </style>
   </head>
   <body>
     <div class="image-container flex flex-wrap">
@@ -17,6 +23,8 @@
       <div class="with-background-img"></div>
       <div class="with-external-background-img"></div>
       <div class="with-rewritten-background-img"></div>
+      <div class="with-rewritten-background-img-inline"></div>
+      <div style="background: url('/img?url=fixtures/pink.png'); no-repeat center;"></div>
     </div>
   </body>
 </html>

--- a/src/write-archive/dom-snapshot.test.ts
+++ b/src/write-archive/dom-snapshot.test.ts
@@ -1,0 +1,36 @@
+import { DOMSnapshot } from './dom-snapshot';
+
+const relativeUrl = '/images/image.png';
+const externalUrl = 'https://chromatic.com/img';
+const queryUrl = '/images/img?src=https://chromatic.com/img';
+const queryUrlTransformed = '/images/somehash.png';
+
+function createSnapshot(url1: string, url2: string, url3: string) {
+  return `{"type":0,"childNodes":[{"type":1,"name":"html","publicId":"","systemId":"","id":2},{"type":2,"tagName":"html","attributes":{},"childNodes":[{"type":2,"tagName":"head","attributes":{},"childNodes":[{"type":3,"textContent":"    ","id":5},{"type":2,"tagName":"link","attributes":{"rel":"stylesheet","href":"/styles-test.css"},"childNodes":[],"id":6},{"type":3,"textContent":"    ","id":7},{"type":2,"tagName":"style","attributes":{},"childNodes":[{"type":3,"textContent":".test1 { background-image: url(\\"${url1}\\"); }.test2 { background-image: url(\\"${url2}\\"); }.test2 { background-image: url(\\"${url3}\\"); }","isStyle":true,"id":9}],"id":8},{"type":3,"textContent":"  ","id":10}],"id":4},{"type":3,"textContent":"  ","id":11},{"type":2,"tagName":"body","attributes":{},"childNodes":[{"type":3,"textContent":"    ","id":13},{"type":2,"tagName":"div","attributes":{"class":"image-container flex flex-wrap"},"childNodes":[{"type":3,"textContent":"      ","id":15},{"type":2,"tagName":"img","attributes":{"src":"${url1}"},"childNodes":[],"id":16},{"type":3,"textContent":"      ","id":17},{"type":2,"tagName":"img","attributes":{"src":"${url2}"},"childNodes":[],"id":18},{"type":3,"textContent":"      ","id":19},{"type":2,"tagName":"img","attributes":{"src":"${url3}"},"childNodes":[],"id":20},{"type":3,"textContent":"      ","id":21},{"type":2,"tagName":"div","attributes":{"style":"background: url('${url1}'); no-repeat center;"},"childNodes":[],"id":22},{"type":3,"textContent":"      ","id":23},{"type":2,"tagName":"div","attributes":{"style":"background: url('${url2}'); no-repeat center;"},"childNodes":[],"id":24},{"type":3,"textContent":"      ","id":25},{"type":2,"tagName":"div","attributes":{"style":"background: url('${url3}'); no-repeat center;"},"childNodes":[],"id":26},{"type":3,"textContent":"    ","id":27}],"id":14},{"type":3,"textContent":"  ","id":28}],"id":12}],"id":3}],"id":1}`;
+}
+
+const snapshot = createSnapshot(relativeUrl, externalUrl, queryUrl);
+const expectedMappedSnapshot = createSnapshot(relativeUrl, externalUrl, queryUrlTransformed);
+
+const sourceMap = new Map<string, string>();
+sourceMap.set(queryUrl, queryUrlTransformed);
+
+describe('DOMSnapshot', () => {
+  describe('mapAssetPaths', () => {
+    it('maps asset paths in src attrs, style attrs, and external style sheets, and inline style elements', async () => {
+      const domSnapshot = new DOMSnapshot(snapshot);
+
+      const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
+
+      expect(mappedSnapshot).toEqual(expectedMappedSnapshot);
+    });
+
+    it('does not change paths that are not in the source map', async () => {
+      const domSnapshot = new DOMSnapshot(snapshot);
+
+      const mappedSnapshot = await domSnapshot.mapAssetPaths(new Map<string, string>());
+
+      expect(mappedSnapshot).toEqual(snapshot);
+    });
+  });
+});

--- a/src/write-archive/dom-snapshot.ts
+++ b/src/write-archive/dom-snapshot.ts
@@ -1,0 +1,54 @@
+import type { elementNode } from '@chromaui/rrweb-snapshot';
+
+/**
+ * TODO rrweb flavored dom snapshot
+ */
+export class DOMSnapshot {
+  snapshot: Buffer;
+
+  constructor(snapshot: Buffer) {
+    this.snapshot = snapshot;
+  }
+
+  async mapSourceEntries(sourceMap: Map<string, string>) {
+    const transformedSnapshot = await this.mapNode(this.snapshot, sourceMap);
+    return Buffer.from(JSON.stringify(transformedSnapshot));
+  }
+
+  async mapNode(domSnapshot: Buffer, sourceMap: Map<string, string>) {
+    let jsonBuffer: elementNode;
+    if (Buffer.isBuffer(domSnapshot)) {
+      const bufferAsString = domSnapshot.toString('utf-8');
+
+      // Try to parse as JSON. Our tests don't always return JSON, so this is kind of a hack
+      // to avoid a situation where JSON is expected but not actually given.
+      try {
+        jsonBuffer = JSON.parse(bufferAsString);
+      } catch (err) {
+        return domSnapshot;
+      }
+    } else {
+      jsonBuffer = domSnapshot;
+    }
+
+    if (jsonBuffer.attributes && jsonBuffer.attributes.src) {
+      const sourceVal = jsonBuffer.attributes.src as string;
+      if (sourceMap.has(sourceVal)) {
+        jsonBuffer.attributes.src = sourceMap.get(sourceVal);
+      }
+    }
+
+    if (jsonBuffer.childNodes) {
+      jsonBuffer.childNodes = await Promise.all(
+        jsonBuffer.childNodes.map(async (child) => {
+          const jsonString = JSON.stringify(child);
+          const mappedSourceEntriesBuffer = await this.mapNode(Buffer.from(jsonString), sourceMap);
+          const mappedSourceEntries = JSON.parse(mappedSourceEntriesBuffer.toString('utf-8'));
+          return mappedSourceEntries;
+        })
+      );
+    }
+
+    return Buffer.from(JSON.stringify(jsonBuffer));
+  }
+}

--- a/src/write-archive/dom-snapshot.ts
+++ b/src/write-archive/dom-snapshot.ts
@@ -3,16 +3,16 @@
 import type { serializedNodeWithId } from '@chromaui/rrweb-snapshot';
 import { NodeType } from '@chromaui/rrweb-snapshot';
 
+// Matches `url(...)` function in CSS text, excluding data URLs
 const CSS_URL_REGEX = /url\((?!['"]?(?:data):)['"]?([^'")]*)['"]?\)/gi;
 
 /**
- * TODO rrweb flavored dom snapshot
+ * Wraps a snapshot from rrweb and handles post-processing to remap asset paths.
  */
 export class DOMSnapshot {
   snapshot: serializedNodeWithId;
 
   constructor(snapshot: Buffer | string) {
-    // TODO do we need to handle string here?
     if (Buffer.isBuffer(snapshot)) {
       const bufferAsString = snapshot.toString('utf-8');
       this.snapshot = JSON.parse(bufferAsString);
@@ -21,7 +21,7 @@ export class DOMSnapshot {
     }
   }
 
-  async mapSourceEntries(sourceMap: Map<string, string>) {
+  async mapAssetPaths(sourceMap: Map<string, string>) {
     const transformedSnapshot = await this.mapNode(this.snapshot, sourceMap);
     return JSON.stringify(transformedSnapshot);
   }
@@ -56,7 +56,7 @@ export class DOMSnapshot {
         node.attributes.style = mappedCssText;
       }
 
-      // This is how rr-web stores the contents of an external stylesheet
+      // This is how rrweb stores the contents of an external stylesheet
       // that it will put into a `style` tag on render
       if (node.attributes._cssText) {
         const cssText = node.attributes._cssText as string;

--- a/src/write-archive/dom-snapshot.ts
+++ b/src/write-archive/dom-snapshot.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 /* eslint-disable no-param-reassign */
 import type { serializedNodeWithId } from '@chromaui/rrweb-snapshot';
 import { NodeType } from '@chromaui/rrweb-snapshot';
@@ -27,6 +28,7 @@ export class DOMSnapshot {
 
   private async mapNode(node: serializedNodeWithId, sourceMap: Map<string, string>) {
     node = this.mapNodeAttributes(node, sourceMap);
+    node = this.mapTextElement(node, sourceMap);
 
     if ('childNodes' in node) {
       node.childNodes = await Promise.all(
@@ -53,6 +55,25 @@ export class DOMSnapshot {
         const mappedCssText = this.mapCssUrls(cssText, sourceMap);
         node.attributes.style = mappedCssText;
       }
+
+      // This is how rr-web stores the contents of an external stylesheet
+      // that it will put into a `style` tag on render
+      if (node.attributes._cssText) {
+        const cssText = node.attributes._cssText as string;
+        const mappedCssText = this.mapCssUrls(cssText, sourceMap);
+        node.attributes._cssText = mappedCssText;
+      }
+    }
+
+    return node;
+  }
+
+  private mapTextElement(node: serializedNodeWithId, sourceMap: Map<string, string>) {
+    if (node.type === NodeType.Text && node.isStyle) {
+      if (node.textContent) {
+        const mappedCssText = this.mapCssUrls(node.textContent, sourceMap);
+        node.textContent = mappedCssText;
+      }
     }
 
     return node;
@@ -68,4 +89,5 @@ export class DOMSnapshot {
     });
   }
 }
+/* eslint-enable no-underscore-dangle */
 /* eslint-enable no-param-reassign */

--- a/src/write-archive/index.ts
+++ b/src/write-archive/index.ts
@@ -66,7 +66,7 @@ export async function writeTestResult(
     // XXX_jwir3: We go through our stories here and map any instances that are found in
     //            the keys of the source map to their respective values.
     const snapshot = new DOMSnapshot(domSnapshot);
-    const mappedSnapshot = await snapshot.mapSourceEntries(sourceMap);
+    const mappedSnapshot = await snapshot.mapAssetPaths(sourceMap);
 
     await outputFile(
       join(archiveDir, `${sanitize(title)}-${sanitize(name)}.snapshot.json`),

--- a/src/write-archive/index.ts
+++ b/src/write-archive/index.ts
@@ -1,9 +1,9 @@
 import { outputFile, ensureDir, outputJson } from 'fs-extra';
 import { join } from 'path';
 import type { TestInfo } from '@playwright/test';
-import type { elementNode } from '@chromaui/rrweb-snapshot';
 import { logger } from '../utils/logger';
 import { ArchiveFile } from './archive-file';
+import { DOMSnapshot } from './dom-snapshot';
 import type { ResourceArchive } from '../resource-archive';
 import type { ChromaticStorybookParameters } from '../types';
 
@@ -65,7 +65,8 @@ export async function writeTestResult(
   await Object.entries(domSnapshots).map(async ([name, domSnapshot]) => {
     // XXX_jwir3: We go through our stories here and map any instances that are found in
     //            the keys of the source map to their respective values.
-    const mappedSnapshot = await mapSourceEntries(domSnapshot, sourceMap);
+    const snapshot = new DOMSnapshot(domSnapshot);
+    const mappedSnapshot = await snapshot.mapSourceEntries(sourceMap);
 
     await outputFile(
       join(archiveDir, `${sanitize(title)}-${sanitize(name)}.snapshot.json`),
@@ -87,55 +88,6 @@ export async function writeTestResult(
       errors: Object.fromEntries(errors),
     });
   }
-}
-
-/**
- * Accepts a DOM snapshot, which is either a `Buffer` or an object in json form, and maps all `src` attributes that are equivalent to
- * one of the entries in the `sourceMap` to the resulting value.
- *
- * @param domSnapshot The DOM snapshot upon which to run the mapping, as a Buffer
- * @param sourceMap A mapping of `string` objects to other `string` objects. All `src` attributes that are keys in this map will be
- *                  adjusted to be the resulting value.
- * @returns A JSON string representing the mapped DOM snapshot.
- */
-async function mapSourceEntries(domSnapshot: Buffer, sourceMap: Map<string, string>) {
-  let jsonBuffer: elementNode;
-  if (Buffer.isBuffer(domSnapshot)) {
-    const bufferAsString = domSnapshot.toString('utf-8');
-
-    // Try to parse as JSON. Our tests don't always return JSON, so this is kind of a hack
-    // to avoid a situation where JSON is expected but not actually given.
-    try {
-      jsonBuffer = JSON.parse(bufferAsString);
-    } catch (err) {
-      return domSnapshot;
-    }
-  } else {
-    jsonBuffer = domSnapshot;
-  }
-
-  if (jsonBuffer.attributes && jsonBuffer.attributes.src) {
-    const sourceVal = jsonBuffer.attributes.src as string;
-    if (sourceMap.has(sourceVal)) {
-      jsonBuffer.attributes.src = sourceMap.get(sourceVal);
-    }
-  }
-
-  if (jsonBuffer.childNodes) {
-    jsonBuffer.childNodes = await Promise.all(
-      jsonBuffer.childNodes.map(async (child) => {
-        const jsonString = JSON.stringify(child);
-        const mappedSourceEntriesBuffer = await mapSourceEntries(
-          Buffer.from(jsonString),
-          sourceMap
-        );
-        const mappedSourceEntries = JSON.parse(mappedSourceEntriesBuffer.toString('utf-8'));
-        return mappedSourceEntries;
-      })
-    );
-  }
-
-  return Buffer.from(JSON.stringify(jsonBuffer));
 }
 
 async function writeStoriesFile(

--- a/src/write-archive/index.ts
+++ b/src/write-archive/index.ts
@@ -62,17 +62,19 @@ export async function writeTestResult(
     })
   );
 
-  await Object.entries(domSnapshots).map(async ([name, domSnapshot]) => {
-    // XXX_jwir3: We go through our stories here and map any instances that are found in
-    //            the keys of the source map to their respective values.
-    const snapshot = new DOMSnapshot(domSnapshot);
-    const mappedSnapshot = await snapshot.mapAssetPaths(sourceMap);
+  await Promise.all(
+    await Object.entries(domSnapshots).map(async ([name, domSnapshot]) => {
+      // XXX_jwir3: We go through our stories here and map any instances that are found in
+      //            the keys of the source map to their respective values.
+      const snapshot = new DOMSnapshot(domSnapshot);
+      const mappedSnapshot = await snapshot.mapAssetPaths(sourceMap);
 
-    await outputFile(
-      join(archiveDir, `${sanitize(title)}-${sanitize(name)}.snapshot.json`),
-      mappedSnapshot
-    );
-  });
+      await outputFile(
+        join(archiveDir, `${sanitize(title)}-${sanitize(name)}.snapshot.json`),
+        mappedSnapshot
+      );
+    })
+  );
 
   await writeStoriesFile(
     join(finalOutputDir, `${sanitize(title)}.stories.json`),


### PR DESCRIPTION
Issue: CAP-1329

## What Changed

<!-- Insert a description below. -->
When we need to rewrite an asset path, we're currently only updating the `src` attribute on DOM nodes. If an asset loaded from a CSS file or `style` attribute was rewritten, it will fail to load because the CSS will reference the old path when the snapshot is rendered.

This goes through the contents of `style` attributes and `style` elements and replaces any `url` references as needed.

There's still one empty box in the E2E Storybook due to a missing asset, but that's due to CAP-1194. I believe getting rid of the rrweb fork, which can be a follow up to this, will resolve that.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
* Run canary against some test projects
* Check out Chromatic build

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.37--canary.33.f9c5b5b.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/test-archiver@0.0.37--canary.33.f9c5b5b.0
  # or 
  yarn add @chromaui/test-archiver@0.0.37--canary.33.f9c5b5b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
