### PR TITLE
Remove asset caching

### DIFF
--- a/src/resource-archive/index.ts
+++ b/src/resource-archive/index.ts
@@ -136,6 +136,12 @@ class Watcher {
       return;
     }
 
+    // There's no reponse body for us to archive on 304s
+    if (responseStatusCode === 304) {
+      await this.clientSend(request, 'Fetch.continueRequest', { requestId });
+      return;
+    }
+
     const requestUrl = new URL(request.url);
 
     this.firstUrl ??= requestUrl;

--- a/src/resource-archive/index.ts
+++ b/src/resource-archive/index.ts
@@ -202,24 +202,6 @@ class Watcher {
       return;
     }
 
-    const response = this.archive[request.url];
-    if (response && 'statusCode' in response) {
-      logger.log(`pausing request we've seen before, sending previous response`);
-      logger.log({
-        requestId,
-        responseCode: response.statusCode,
-        responsePhrase: response.statusText,
-      });
-      await this.clientSend(request, 'Fetch.fulfillRequest', {
-        requestId,
-        responseCode: response.statusCode,
-        ...(response.statusText && { responsePhrase: response.statusText }),
-        // responseHeaders: response.headers, TODO - mapping
-        body: response.body.toString('base64'),
-      });
-      return;
-    }
-
     await this.clientSend(request, 'Fetch.continueRequest', {
       requestId,
       interceptResponse: true,


### PR DESCRIPTION
Issue: AP-3979

## What Changed

Removes the asset caching that was breaking multi-page flows because the cached responses being used were missing critical headers, like `content-type`. I don't think we're gaining much by caching so let's not.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.45--canary.43.3d53d71.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/test-archiver@0.0.45--canary.43.3d53d71.0
  # or 
  yarn add @chromaui/test-archiver@0.0.45--canary.43.3d53d71.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
