### PR TITLE
Chrome Devtools Protocol code is framework-agnostic

### DIFF
--- a/src/playwright-api/createResourceArchive.test.ts
+++ b/src/playwright-api/createResourceArchive.test.ts
@@ -3,7 +3,7 @@ import express, { type Request } from 'express';
 import { Server } from 'http';
 import { Browser, chromium, Page } from 'playwright';
 
-import { createResourceArchive } from './index';
+import { createResourceArchive } from './createResourceArchive';
 import { logger } from '../utils/logger';
 
 const TEST_PORT = 13337;

--- a/src/playwright-api/createResourceArchive.ts
+++ b/src/playwright-api/createResourceArchive.ts
@@ -1,0 +1,28 @@
+import type { Page } from 'playwright';
+import { Watcher, ResourceArchive } from '../resource-archive';
+import { DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS } from '../constants';
+
+export const createResourceArchive = async ({
+  page,
+  networkTimeout,
+  allowedArchiveDomains,
+}: {
+  page: Page;
+  networkTimeout?: number;
+  allowedArchiveDomains?: string[];
+}): Promise<() => Promise<ResourceArchive>> => {
+  const cdpClient = await page.context().newCDPSession(page);
+
+  const watcher = new Watcher(
+    cdpClient,
+    networkTimeout ?? DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS,
+    allowedArchiveDomains
+  );
+  await watcher.watch();
+
+  return async () => {
+    await watcher.idle(page);
+
+    return watcher.archive;
+  };
+};

--- a/src/playwright-api/makeTest.ts
+++ b/src/playwright-api/makeTest.ts
@@ -6,11 +6,11 @@ import type {
   PlaywrightWorkerOptions,
 } from '@playwright/test';
 import type { ChromaticConfig } from '../types';
-import { createResourceArchive } from '../resource-archive';
 import { writeTestResult } from '../write-archive';
 import { contentType, takeArchive } from './takeArchive';
 import { trackComplete, trackRun } from '../utils/analytics';
 import { DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS } from '../constants';
+import { createResourceArchive } from './createResourceArchive';
 
 // We do this slightly odd thing (makeTest) to avoid importing playwright multiple times when
 // linking this package. To avoid the main entry, you can:

--- a/src/resource-archive/index.ts
+++ b/src/resource-archive/index.ts
@@ -19,7 +19,7 @@ export type ArchiveResponse =
 
 export type ResourceArchive = Record<UrlString, ArchiveResponse>;
 
-class Watcher {
+export class Watcher {
   public archive: ResourceArchive = {};
 
   private client: CDPSession;
@@ -212,29 +212,4 @@ class Watcher {
       interceptResponse: true,
     });
   }
-}
-
-export async function createResourceArchive({
-  page,
-  networkTimeout,
-  allowedArchiveDomains,
-}: {
-  page: Page;
-  networkTimeout?: number;
-  allowedArchiveDomains?: string[];
-}): Promise<() => Promise<ResourceArchive>> {
-  const cdpClient = await page.context().newCDPSession(page);
-
-  const watcher = new Watcher(
-    cdpClient,
-    networkTimeout ?? DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS,
-    allowedArchiveDomains
-  );
-  await watcher.watch();
-
-  return async () => {
-    await watcher.idle(page);
-
-    return watcher.archive;
-  };
 }


### PR DESCRIPTION
## What Changed

<!-- Insert a description below. -->
This PR removes (most of) the Playwright-specific stuff inside the CDP-interfacing code. This is so that we can easily use the same code with Cypress in a future PR.

The idea is that each testing framework can provide its own `cdpClient` to the `Watcher` class, leaving the `Watcher` uninvolved with framework-specific things.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
- [x] Watch the CI tests pass
- [ ] Inspect the published storybook to ensure all images are loaded as they did before

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
