### PR TITLE
Cypress doesn't wait for idle timeout

### DIFF
--- a/src/cypress-api/index.ts
+++ b/src/cypress-api/index.ts
@@ -88,7 +88,7 @@ export const setupNetworkListener = async (): Promise<null> => {
 export const saveArchives = (archiveInfo: WriteParams) => {
   return new Promise((resolve) => {
     // the watcher's archives come from the server, everything else (DOM snapshots, test info, etc) comes from the browser
-    // notice we're not awaiting watcher.idle() here...
+    // notice we're not calling + awaiting watcher.idle() here...
     // that's because in Cypress, cy.visit() waits until all resources have loaded before finishing
     // so at this point (after the test) we're confident that the resources are all there already without having to wait more
     return writeArchives({ ...archiveInfo, resourceArchive: watcher.archive }).then(() => {

--- a/src/cypress-api/index.ts
+++ b/src/cypress-api/index.ts
@@ -87,11 +87,12 @@ export const setupNetworkListener = async (): Promise<null> => {
 
 export const saveArchives = (archiveInfo: WriteParams) => {
   return new Promise((resolve) => {
-    return watcher.idle().then(() => {
-      // the watcher's archives come from the server, everything else (DOM snapshots, test info, etc) comes from the browser
-      return writeArchives({ ...archiveInfo, resourceArchive: watcher.archive }).then(() => {
-        resolve(null);
-      });
+    // the watcher's archives come from the server, everything else (DOM snapshots, test info, etc) comes from the browser
+    // notice we're not awaiting watcher.idle() here...
+    // that's because in Cypress, cy.visit() waits until all resources have loaded before finishing
+    // so at this point (after the test) we're confident that the resources are all there already without having to wait more
+    return writeArchives({ ...archiveInfo, resourceArchive: watcher.archive }).then(() => {
+      resolve(null);
     });
   });
 };

--- a/src/playwright-api/createResourceArchive.ts
+++ b/src/playwright-api/createResourceArchive.ts
@@ -1,6 +1,33 @@
 import type { Page } from 'playwright';
 import { Watcher, ResourceArchive } from '../resource-archive';
 import { DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS } from '../constants';
+import { logger } from '../utils/logger';
+
+const idle = async (page: Page, networkTimeoutMs = DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS) => {
+  let globalNetworkTimerId: null | ReturnType<typeof setTimeout> = null;
+  let globalNetworkResolver: null | (() => void) = null;
+  // XXX_jwir3: The way this works is as follows:
+  // There are two promises created here. They wrap two separate timers, and we await on a race of both Promises.
+
+  // The first promise wraps a global timeout, where all requests MUST complete before that timeout has passed.
+  // If the timeout passes, an error is thrown. This promise can only throw errors, it cannot resolve successfully.
+  const globalNetworkTimeout = new Promise<void>((resolve) => {
+    globalNetworkResolver = resolve;
+
+    globalNetworkTimerId = setTimeout(() => {
+      logger.warn(`Global timeout of ${networkTimeoutMs}ms reached`);
+      globalNetworkResolver();
+    }, networkTimeoutMs);
+  });
+
+  // The second promise wraps a network idle timeout. This uses playwright's built-in functionality to detect when the network
+  // is idle.
+  const networkIdlePromise = page.waitForLoadState('networkidle').finally(() => {
+    clearTimeout(globalNetworkTimerId);
+  });
+
+  await Promise.race([globalNetworkTimeout, networkIdlePromise]);
+};
 
 export const createResourceArchive = async ({
   page,
@@ -17,7 +44,7 @@ export const createResourceArchive = async ({
   await watcher.watch();
 
   return async () => {
-    await watcher.idle(page, networkTimeout ?? DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS);
+    await idle(page, networkTimeout ?? DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS);
 
     return watcher.archive;
   };

--- a/src/playwright-api/createResourceArchive.ts
+++ b/src/playwright-api/createResourceArchive.ts
@@ -13,15 +13,11 @@ export const createResourceArchive = async ({
 }): Promise<() => Promise<ResourceArchive>> => {
   const cdpClient = await page.context().newCDPSession(page);
 
-  const watcher = new Watcher(
-    cdpClient,
-    networkTimeout ?? DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS,
-    allowedArchiveDomains
-  );
+  const watcher = new Watcher(cdpClient, allowedArchiveDomains);
   await watcher.watch();
 
   return async () => {
-    await watcher.idle(page);
+    await watcher.idle(page, networkTimeout ?? DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS);
 
     return watcher.archive;
   };

--- a/src/resource-archive/index.ts
+++ b/src/resource-archive/index.ts
@@ -45,8 +45,6 @@ export class Watcher {
    */
   private firstUrl: URL;
 
-  private closed = false;
-
   private globalNetworkTimerId: null | ReturnType<typeof setTimeout> = null;
 
   private globalNetworkResolver: () => void;
@@ -99,9 +97,6 @@ export class Watcher {
     }
 
     await Promise.race(promises);
-
-    logger.log('Watcher closing');
-    this.closed = true;
   }
 
   setResponse(url: UrlString, response: ArchiveResponse) {
@@ -168,10 +163,6 @@ export class Watcher {
       this.firstUrl.toString(),
       isRequestFromAllowedDomain
     );
-
-    if (this.closed) {
-      logger.log('Watcher closed, ignoring');
-    }
 
     // Pausing at response stage with an error, simply ignore
     if (responseErrorReason) {

--- a/src/resource-archive/index.ts
+++ b/src/resource-archive/index.ts
@@ -52,8 +52,6 @@ export class Watcher {
   }
 
   async watch() {
-    this.client.on('Network.requestWillBeSent', this.requestWillBeSent.bind(this));
-    this.client.on('Network.responseReceived', this.responseReceived.bind(this));
     this.client.on('Fetch.requestPaused', this.requestPaused.bind(this));
 
     await this.client.send('Fetch.enable');
@@ -86,16 +84,6 @@ export class Watcher {
 
   setResponse(url: UrlString, response: ArchiveResponse) {
     this.archive[url] = response;
-  }
-
-  requestWillBeSent(event: Protocol.Network.requestWillBeSentPayload) {
-    logger.log('requestWillBeSent');
-    logger.log(event);
-  }
-
-  responseReceived(event: Protocol.Network.responseReceivedPayload) {
-    logger.log('responseReceived');
-    logger.log(event);
   }
 
   async clientSend<T extends keyof Protocol.CommandParameters>(


### PR DESCRIPTION
## What Changed

<!-- Insert a description below. -->

Cypress doesn't wait 10 seconds (the global timeout amount) to finish tests anymore.

Instead of using the `Watcher.idle()` to know when Cypress archives can be complete, I'm not waiting at all. This is because `cy.visit()` (the command to visit a page) already waits for all resources to be loaded before it completes. 

This also means users' Cypress tests aren't any slower when they add Chromatic since we're not waiting a minimum of `500ms` after each test.

### Also changed
* `Watcher.idle()` is pulled out and into the Playwright-specific code since 1) Cypress doesn't need it and 2) it doesn't need access to any `Watcher` class variables
* I removed a couple `Watcher` methods that were either 1) unused (`setResponse()`) or 2) were only used for logging and weren't actually ever even hit (`requestWillBeSent()` and `responseReceived()`)

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
* Watch the tests pass below
* Locally, run Playwright tests
* Verify that Playwright tests still finish once network is idle
* Verify that Playwright tests still wait until global timeout (10 seconds) if network isn't idle
* Locally, run Cypress tests
* Verify that Cypress tests run quickly (not waiting 10 seconds between tests as they did before).

- [x] Author QA


## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.55--canary.54.b107684.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/test-archiver@0.0.55--canary.54.b107684.0
  # or 
  yarn add @chromaui/test-archiver@0.0.55--canary.54.b107684.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
