### PR TITLE
Cypress: User-facing API

### DIFF
--- a/src/cypress-api/index.ts
+++ b/src/cypress-api/index.ts
@@ -63,7 +63,7 @@ let watcher: Watcher = null;
 let host = '';
 let port = 0;
 
-export const setupNetworkListener = async (): Promise<null> => {
+const setupNetworkListener = async (): Promise<null> => {
   try {
     const { webSocketDebuggerUrl } = await Version({
       host,
@@ -85,7 +85,7 @@ export const setupNetworkListener = async (): Promise<null> => {
   return null;
 };
 
-export const saveArchives = (archiveInfo: WriteParams) => {
+const saveArchives = (archiveInfo: WriteParams) => {
   return new Promise((resolve) => {
     // the watcher's archives come from the server, everything else (DOM snapshots, test info, etc) comes from the browser
     // notice we're not calling + awaiting watcher.idle() here...
@@ -124,4 +124,13 @@ export const onBeforeBrowserLaunch = (
   port = parseInt(portString, 10);
 
   return launchOptions;
+};
+
+export const installPlugin = (on: any) => {
+  // these events are run on the server (in Node)
+  on('task', {
+    setupNetworkListener,
+    saveArchives,
+  });
+  on('before:browser:launch', onBeforeBrowserLaunch);
 };

--- a/src/cypress-api/index.ts
+++ b/src/cypress-api/index.ts
@@ -97,6 +97,25 @@ const saveArchives = (archiveInfo: WriteParams) => {
   });
 };
 
+interface TaskParams {
+  action: 'setup-network-listener' | 'save-archives';
+  payload?: any;
+}
+
+// Handles all server-side tasks, dispatching each to its proper handler.
+// Why? So users don't have to register all these individual tasks
+// (they can just import and register prepareArchives)
+export const prepareArchives = async ({ action, payload }: TaskParams) => {
+  switch (action) {
+    case 'setup-network-listener':
+      return setupNetworkListener();
+    case 'save-archives':
+      return saveArchives(payload);
+    default:
+      return null;
+  }
+};
+
 // We use this lifecycle hook because we need to know what host and port Chrome Devtools Protocol is listening at.
 export const onBeforeBrowserLaunch = (
   // we don't use the browser parameter but we're keeping it here in case we'd ever need to read from it
@@ -129,8 +148,7 @@ export const onBeforeBrowserLaunch = (
 export const installPlugin = (on: any) => {
   // these events are run on the server (in Node)
   on('task', {
-    setupNetworkListener,
-    saveArchives,
+    prepareArchives,
   });
   on('before:browser:launch', onBeforeBrowserLaunch);
 };

--- a/src/cypress-api/support.ts
+++ b/src/cypress-api/support.ts
@@ -7,7 +7,7 @@ beforeEach(() => {
   // then cleaned up before the next test is run
   // (see https://docs.cypress.io/guides/core-concepts/variables-and-aliases#Aliases)
   cy.wrap([]).as('manualSnapshots');
-  cy.task('setupNetworkListener');
+  cy.task('prepareArchives', { action: 'setup-network-listener' });
 });
 
 afterEach(() => {
@@ -18,13 +18,16 @@ afterEach(() => {
     cy.get('@manualSnapshots').then((manualSnapshots = []) => {
       cy.url().then((url) => {
         // pass the snapshot to the server to write to disk
-        cy.task('saveArchives', {
-          testTitle: Cypress.currentTest.title,
-          domSnapshots: [...manualSnapshots, snap],
-          chromaticStorybookParams: {
-            diffThreshold: Cypress.env('diffThreshold'),
+        cy.task('prepareArchives', {
+          action: 'save-archives',
+          payload: {
+            testTitle: Cypress.currentTest.title,
+            domSnapshots: [...manualSnapshots, snap],
+            chromaticStorybookParams: {
+              diffThreshold: Cypress.env('diffThreshold'),
+            },
+            pageUrl: url,
           },
-          pageUrl: url,
         });
       });
     });

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'cypress';
-import { setupNetworkListener, onBeforeBrowserLaunch, saveArchives } from '../src/cypress-api';
+import { installPlugin } from '../src/cypress-api';
 
 export default defineConfig({
   // needed since we use common mock images between Cypress and Playwright
@@ -8,12 +8,7 @@ export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:3000',
     setupNodeEvents(on, config) {
-      // these events are run on the server (in Node)
-      on('task', {
-        setupNetworkListener,
-        saveArchives,
-      });
-      on('before:browser:launch', onBeforeBrowserLaunch);
+      installPlugin(on);
     },
   },
 });


### PR DESCRIPTION
## What Changed

<!-- Insert a description below. -->

Simplified the user API as follows:

Before:
```ts
import { defineConfig } from 'cypress';
import { setupNetworkListener, onBeforeBrowserLaunch, saveArchives } from '@chromaui/test-archiver/cypress';

export default defineConfig({
  e2e: {
    setupNodeEvents(on, config) {
      on('task', {
        setupNetworkListener,
        saveArchives,
      });
      on('before:browser:launch', onBeforeBrowserLaunch);
    },
  },
});

```

After:
```ts
import { defineConfig } from 'cypress';
import { installPlugin } from '@chromaui/test-archiver/cypress';

export default defineConfig({
  e2e: {
    setupNodeEvents(on, config) {
      installPlugin(on);
    },
  },
});
```

The user still needs to import our client-side beforeEach/afterEach hooks in their support file:
```ts
import '@chromaui/test-archiver/cypress/support';
```
The user will unfortunately also still have to pass
`ELECTRON_EXTRA_LAUNCH_ARGS=--remote-debugging-port=x` in front of their `cypress run` command still. Cypress doesn't allow for specifying a remote debugging port for Chrome, and electron doesn't pass the browser launch options (info like the CDP port), so we're stuck needing this `ELECTRON_EXTRA_LAUNCH_ARGS` env variable set by the user if they use Electron (which is the default for `cypress run`). Technically they don't need it if they are using Chrome/Chromium, but I think it's better to have all users add this then have a bunch of if-this-then-that's in our setup guide.

### Note
Cypress lifecycle events can only be registered once. Because our `installPlugin()` registers an event listener on `before:browser:launch` event, if the user has such an event already, they will need to call `installPlugin()` first, and then register their `before:browser:launch` event, as follows:

```ts
import { defineConfig } from 'cypress';
import { installPlugin, onBeforeBrowserLaunch } from '@chromaui/test-archiver/cypress';

export default defineConfig({
  e2e: {
    setupNodeEvents(on, config) {
      installPlugin(on);
      on('before:browser:launch', (browser, launchOptions) => {
           // register our event handler manually
           onBeforeBrowserLaunch(browser, launchOptions);
          doWhateverTheyDo(browser, launchOptions);
          return launchOptions;
     });
    },
  },
});
```

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
* Verify the automated Cypress tests still pass (here in PR checks)
* Locally, create a Cypress project and install this package version
* Change your `cypress.config.ts` file to match the new API
* Run the Cypress tests with `yarn cypress run`
* Verify the Cypress test run completes as expected
* Run `yarn archive-storybook`
* Verify that the storybook has the stories as before

- [x] Author QA
- [ ] Reviewer QA

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.56--canary.55.8655fbb.1</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/test-archiver@0.0.56--canary.55.8655fbb.1
  # or 
  yarn add @chromaui/test-archiver@0.0.56--canary.55.8655fbb.1
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
