### PR TITLE
Update function/parameter names

### DIFF
--- a/packages/playwright/src/createResourceArchive.test.ts
+++ b/packages/playwright/src/createResourceArchive.test.ts
@@ -173,7 +173,7 @@ describe('new', () => {
 
     const complete = await createResourceArchive({
       page,
-      allowedArchiveDomains: [
+      assetDomains: [
         // external domains we allow-list
         'i-ama.fake',
         'another-domain.com',

--- a/packages/playwright/src/createResourceArchive.ts
+++ b/packages/playwright/src/createResourceArchive.ts
@@ -35,15 +35,15 @@ const idle = async (page: Page, networkTimeoutMs = DEFAULT_GLOBAL_RESOURCE_ARCHI
 export const createResourceArchive = async ({
   page,
   networkTimeout,
-  allowedArchiveDomains,
+  assetDomains,
 }: {
   page: Page;
   networkTimeout?: number;
-  allowedArchiveDomains?: string[];
+  assetDomains?: string[];
 }): Promise<() => Promise<ResourceArchive>> => {
   const cdpClient = await page.context().newCDPSession(page);
 
-  const watcher = new Watcher(cdpClient, allowedArchiveDomains);
+  const watcher = new Watcher(cdpClient, assetDomains);
   await watcher.watch();
 
   return async () => {

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -5,5 +5,5 @@ import { makeTest } from './makeTest';
 export const test = makeTest(base);
 export { expect };
 
-export { takeArchive } from './takeArchive';
+export { takeSnapshot } from './takeSnapshot';
 export type { ChromaticConfig } from '@chromaui/shared-e2e';

--- a/packages/playwright/src/makeTest.ts
+++ b/packages/playwright/src/makeTest.ts
@@ -12,7 +12,7 @@ import {
   trackRun,
   DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS,
 } from '@chromaui/shared-e2e';
-import { contentType, takeArchive } from './takeArchive';
+import { contentType, takeSnapshot } from './takeSnapshot';
 import { createResourceArchive } from './createResourceArchive';
 
 // We do this slightly odd thing (makeTest) to avoid importing playwright multiple times when
@@ -74,7 +74,7 @@ export const makeTest = (
         await use();
 
         if (!disableAutoCapture) {
-          await takeArchive(page, testInfo);
+          await takeSnapshot(page, testInfo);
         }
 
         const resourceArchive = await completeArchive();

--- a/packages/playwright/src/makeTest.ts
+++ b/packages/playwright/src/makeTest.ts
@@ -31,12 +31,12 @@ export const makeTest = (
     delay: [undefined, { option: true }],
     diffIncludeAntiAliasing: [undefined, { option: true }],
     diffThreshold: [undefined, { option: true }],
-    disableAutoCapture: [false, { option: true }],
+    disableAutoSnapshot: [false, { option: true }],
     forcedColors: [undefined, { option: true }],
     pauseAnimationAtEnd: [undefined, { option: true }],
     prefersReducedMotion: [undefined, { option: true }],
     resourceArchiveTimeout: [DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS, { option: true }],
-    allowedArchiveDomains: [[], { option: true }],
+    assetDomains: [[], { option: true }],
 
     save: [
       async (
@@ -45,12 +45,12 @@ export const makeTest = (
           delay,
           diffIncludeAntiAliasing,
           diffThreshold,
-          disableAutoCapture,
+          disableAutoSnapshot,
           forcedColors,
           pauseAnimationAtEnd,
           prefersReducedMotion,
           resourceArchiveTimeout,
-          allowedArchiveDomains,
+          assetDomains,
         },
         use,
         testInfo
@@ -69,11 +69,11 @@ export const makeTest = (
         const completeArchive = await createResourceArchive({
           page,
           networkTimeout: resourceArchiveTimeout,
-          allowedArchiveDomains,
+          assetDomains,
         });
         await use();
 
-        if (!disableAutoCapture) {
+        if (!disableAutoSnapshot) {
           await takeSnapshot(page, testInfo);
         }
 

--- a/packages/playwright/src/takeSnapshot.ts
+++ b/packages/playwright/src/takeSnapshot.ts
@@ -10,9 +10,9 @@ const rrweb = readFileSync(require.resolve('rrweb-snapshot/dist/rrweb-snapshot.j
 
 export const contentType = 'application/rrweb.snapshot+json';
 
-async function takeArchive(page: Page, testInfo: TestInfo): Promise<void>;
-async function takeArchive(page: Page, name: string, testInfo: TestInfo): Promise<void>;
-async function takeArchive(
+async function takeSnapshot(page: Page, testInfo: TestInfo): Promise<void>;
+async function takeSnapshot(page: Page, name: string, testInfo: TestInfo): Promise<void>;
+async function takeSnapshot(
   page: Page,
   nameOrTestInfo: string | TestInfo,
   maybeTestInfo?: TestInfo
@@ -42,4 +42,4 @@ async function takeArchive(
   testInfo.attach(name, { contentType, body: JSON.stringify(domSnapshot) });
 }
 
-export { takeArchive };
+export { takeSnapshot };

--- a/packages/playwright/tests/archiving-assets.spec.ts
+++ b/packages/playwright/tests/archiving-assets.spec.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { test } from '../src';
 
 // domain of external image in test (to archive)
-test.use({ allowedArchiveDomains: ['some.external'] });
+test.use({ assetDomains: ['some.external'] });
 
 test('Assets / query params determine which asset is served', async ({ page }) => {
   await page.goto('/asset-paths/query-params');

--- a/packages/shared/src/resource-archive/index.ts
+++ b/packages/shared/src/resource-archive/index.ts
@@ -31,7 +31,7 @@ export class Watcher {
    Specifies which domains (origins) we should archive resources for (by default we only archive same-origin resources).
    Useful in situations where the environment running the archived storybook (e.g. in CI) may be restricted to an intranet or other domain restrictions
   */
-  private allowedArchiveOrigins: string[];
+  private assetDomains: string[];
 
   /**
    * We assume the first URL loaded after @watch is called is the base URL of the
@@ -43,7 +43,7 @@ export class Watcher {
   constructor(cdpClient: CDPClient, allowedDomains?: string[]) {
     this.client = cdpClient;
     // tack on the protocol so we can properly check if requests are cross-origin
-    this.allowedArchiveOrigins = (allowedDomains || []).map((domain) => `https://${domain}`);
+    this.assetDomains = (allowedDomains || []).map((domain) => `https://${domain}`);
   }
 
   async watch() {
@@ -92,7 +92,7 @@ export class Watcher {
 
     const isRequestFromAllowedDomain =
       requestUrl.origin === this.firstUrl.origin ||
-      this.allowedArchiveOrigins.includes(requestUrl.origin);
+      this.assetDomains.includes(requestUrl.origin);
 
     logger.log(
       'requestPaused',

--- a/packages/shared/src/resource-archive/index.ts
+++ b/packages/shared/src/resource-archive/index.ts
@@ -91,8 +91,7 @@ export class Watcher {
     this.firstUrl ??= requestUrl;
 
     const isRequestFromAllowedDomain =
-      requestUrl.origin === this.firstUrl.origin ||
-      this.assetDomains.includes(requestUrl.origin);
+      requestUrl.origin === this.firstUrl.origin || this.assetDomains.includes(requestUrl.origin);
 
     logger.log(
       'requestPaused',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -9,7 +9,7 @@ export interface ChromaticConfig {
   diffThreshold?: number;
 
   // Disable the capture that happens automatically at the end of a test when using the Chromatic test fixture
-  disableAutoCapture?: boolean;
+  disableAutoSnapshot?: boolean;
 
   // https://www.chromatic.com/docs/media-features/#test-high-contrast-color-schemes
   forcedColors?: string;
@@ -27,9 +27,9 @@ export interface ChromaticConfig {
   // domains (besides where the test is being run from) that assets should be archived from
   // (needed when, for example, CI environment can't access the archives later on)
   // ex: www.some-domain.com
-  allowedArchiveDomains?: string[];
+  assetDomains?: string[];
 }
 
-export interface ChromaticStorybookParameters extends Omit<ChromaticConfig, 'disableAutoCapture'> {
+export interface ChromaticStorybookParameters extends Omit<ChromaticConfig, 'disableAutoSnapshot'> {
   viewports: number[];
 }


### PR DESCRIPTION
Fixes AP-3872

## What Changed

<!-- Insert a description below. -->
This PR updates a few parameter names and functions to be aligned with agreed upon names.

- `takeArchive` → `takeSnapshot`
- `disableAutoCapture` → `disableAutoSnapshot`
- `allowedArchiveDomains` → `assetDomains`

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
1. Run Tests
2. Run a E2E build
