### PR TITLE
Use fullscreen layout to avoid padding in storybook

### DIFF
--- a/packages/shared/storybook-config/preview.ts
+++ b/packages/shared/storybook-config/preview.ts
@@ -53,5 +53,8 @@ const renderToCanvas: RenderToCanvas<RRWebFramework> = async (context, element) 
 
 export default {
   renderToCanvas,
-  parameters: { server: { url: strippedUrl } },
+  parameters: {
+    server: { url: strippedUrl },
+    layout: 'fullscreen',
+  },
 };


### PR DESCRIPTION
Issue: AP-3329

## What Changed

Set Storybook's layout to fullscreen to avoid padding.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
