### PR TITLE
Fix shared package dependencies

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -61,6 +61,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@segment/analytics-node": "^1.1.0",
     "@storybook/csf": "^0.1.0",
     "chrome-remote-interface": "^0.33.0",
     "lodash.debounce": "^4.0.8",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -57,6 +57,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@segment/analytics-node": "^1.1.0",
     "@storybook/csf": "^0.1.0",
     "lodash.debounce": "^4.0.8",
     "rrweb-snapshot": "^2.0.0-alpha.4",

--- a/packages/shared/.eslintrc.js
+++ b/packages/shared/.eslintrc.js
@@ -2,11 +2,9 @@ module.exports = {
   extends: ['@storybook/eslint-config-storybook'],
   overrides: [
     {
-      files: ['**/*.tsx'],
+      files: ['**/*.ts'],
       rules: {
-        'react/prop-types': 'off',
-        'react/require-default-props': 'off',
-        'react/default-props-match-prop-types': 'off',
+        'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
       },
     },
     {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -78,9 +78,11 @@
     "babel-jest": "^27.0.6",
     "concurrently": "^7.0.0",
     "eslint": "^7.32.0",
+    "fs-extra": "^11.1.1",
     "jest": "^27.0.6",
     "jest-environment-jsdom": "^27.0.6",
     "lint-staged": ">=10",
+    "mime": "^3.0.0",
     "node-fetch": "2",
     "playwright": "^1.32.2",
     "playwright-core": "^1.32.2",
@@ -89,6 +91,8 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "rimraf": "^3.0.2",
+    "srcset": "^4.0.0",
+    "ts-dedent": "^2.2.0",
     "ts-jest": "^27.0.4",
     "tsup": "^6.7.0",
     "typescript": "^4.2.4"
@@ -98,10 +102,6 @@
   },
   "dependencies": {
     "@segment/analytics-node": "^1.1.0",
-    "fs-extra": "^11.1.1",
-    "mime": "^3.0.0",
-    "rrweb-snapshot": "^2.0.0-alpha.4",
-    "srcset": "^4.0.0",
-    "ts-dedent": "^2.2.0"
+    "rrweb-snapshot": "^2.0.0-alpha.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8035,6 +8035,7 @@ __metadata:
   resolution: "chromatic-cypress@workspace:packages/cypress"
   dependencies:
     "@chromaui/shared-e2e": "workspace:*"
+    "@segment/analytics-node": "npm:^1.1.0"
     "@storybook/csf": "npm:^0.1.0"
     "@storybook/types": "npm:^7.0.2"
     "@types/lodash.debounce": "npm:^4.0.7"
@@ -8055,6 +8056,7 @@ __metadata:
   dependencies:
     "@chromaui/shared-e2e": "workspace:*"
     "@playwright/test": "npm:^1.39.0"
+    "@segment/analytics-node": "npm:^1.1.0"
     "@storybook/csf": "npm:^0.1.0"
     "@storybook/types": "npm:^7.0.2"
     "@types/lodash.debounce": "npm:^4.0.7"


### PR DESCRIPTION
Issue: #

## What Changed

Regular dependencies of the shared package will be bundled up into the external pw/cy package's code when they are built, unless they are also dependencies of those packages.

This moves most of shared's dependencies to devDependencies so they are bundled up with its code rather than the pw/cy code. Either works, but this feels a bit cleaner.

The couple of packages that haven't been moved are also dependencies of the external pw/cy packages, so they won't get bundled up in those packages. The `@segment/analytics-node` package does not need to be a dependency of those, but it causes compilation warnings when it is bundled so the move is to avoid that.

