### PR TITLE
Cypress: Manual snapshots

### DIFF
--- a/packages/cypress/src/commands.ts
+++ b/packages/cypress/src/commands.ts
@@ -1,7 +1,7 @@
 import { snapshot } from 'rrweb-snapshot';
 import type { elementNode } from 'rrweb-snapshot';
 // @ts-expect-error will fix when Cypress has its own package
-Cypress.Commands.add('takeChromaticArchive', () => {
+Cypress.Commands.add('takeSnapshot', () => {
   cy.document().then((doc) => {
     // here, handle the source map
     const manualSnapshot = snapshot(doc);

--- a/packages/cypress/src/commands.ts
+++ b/packages/cypress/src/commands.ts
@@ -1,7 +1,7 @@
 import { snapshot } from 'rrweb-snapshot';
 import type { elementNode } from 'rrweb-snapshot';
 // @ts-expect-error will fix when Cypress has its own package
-Cypress.Commands.add('takeSnapshot', () => {
+Cypress.Commands.add('takeSnapshot', (name?: string) => {
   cy.document().then((doc) => {
     // here, handle the source map
     const manualSnapshot = snapshot(doc);
@@ -9,7 +9,7 @@ Cypress.Commands.add('takeSnapshot', () => {
     cy.get('@manualSnapshots')
       // @ts-expect-error will fix when Cypress has its own package
       .then((snapshots: elementNode[]) => {
-        return [...snapshots, manualSnapshot];
+        return [...snapshots, { name, snapshot: manualSnapshot }];
       })
       .as('manualSnapshots');
   });

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -7,9 +7,16 @@ import {
   ResourceArchive,
 } from '@chromaui/shared-e2e';
 
+interface CypressSnapshot {
+  // the name of the snapshot (optionally provided for manual snapshots, never provided for automatic snapshots)
+  name?: string;
+  // the DOM snapshot
+  snapshot: elementNode;
+}
+
 interface WriteParams {
   testTitle: string;
-  domSnapshots: elementNode[];
+  domSnapshots: CypressSnapshot[];
   chromaticStorybookParams: ChromaticStorybookParameters;
   pageUrl: string;
 }
@@ -39,7 +46,11 @@ const writeArchives = async ({
   });
 
   const allSnapshots = Object.fromEntries(
-    domSnapshots.map((item, index) => [`Snapshot #${index + 1}`, Buffer.from(JSON.stringify(item))])
+    // manual snapshots can be given a name; otherwise, just use the snapshot's place in line as the name
+    domSnapshots.map(({ name, snapshot }, index) => [
+      name ?? `Snapshot #${index + 1}`,
+      Buffer.from(JSON.stringify(snapshot)),
+    ])
   );
 
   await writeTestResult(

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -19,7 +19,7 @@ afterEach(() => {
   }
   // can we be sure this always fires after all the requests are back?
   cy.document().then((doc) => {
-    const snap = snapshot(doc);
+    const automaticSnapshot = snapshot(doc);
     // @ts-expect-error will fix when Cypress has its own package
     cy.get('@manualSnapshots').then((manualSnapshots = []) => {
       cy.url().then((url) => {
@@ -28,7 +28,7 @@ afterEach(() => {
           action: 'save-archives',
           payload: {
             testTitle: Cypress.currentTest.title,
-            domSnapshots: [...manualSnapshots, snap],
+            domSnapshots: [...manualSnapshots, { snapshot: automaticSnapshot }],
             chromaticStorybookParams: {
               ...(Cypress.env('diffThreshold') && { diffThreshold: Cypress.env('diffThreshold') }),
               ...(Cypress.env('delay') && { delay: Cypress.env('delay') }),

--- a/packages/cypress/tests/cypress/e2e/manual-snapshots.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/manual-snapshots.cy.ts
@@ -1,6 +1,6 @@
 it('Manual Snapshots / multiple snapshots are taken', () => {
   cy.visit('/manual-snapshots');
-  cy.takeSnapshot();
+  cy.takeSnapshot('accordion collapsed');
   cy.contains("I'm an accordion, click me!").click();
   cy.contains('I am hiding inside!').should('be.visible');
 });

--- a/packages/cypress/tests/cypress/e2e/manual-snapshots.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/manual-snapshots.cy.ts
@@ -1,5 +1,5 @@
-it('Assets / query params determine which asset is served', () => {
+it('Manual Snapshots / multiple snapshots are taken', () => {
   cy.visit('/manual-snapshots');
-  cy.takeChromaticArchive();
   cy.contains("I'm an accordion, click me!").click();
+  cy.contains('I am hiding inside!').should('be.visible');
 });

--- a/packages/cypress/tests/cypress/e2e/manual-snapshots.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/manual-snapshots.cy.ts
@@ -1,6 +1,10 @@
 it('Manual Snapshots / multiple snapshots are taken', () => {
   cy.visit('/manual-snapshots');
+  // manual snapshot with name
   cy.takeSnapshot('accordion collapsed');
   cy.contains("I'm an accordion, click me!").click();
-  cy.contains('I am hiding inside!').should('be.visible');
+  // manual snapshot without name
+  cy.takeSnapshot();
+  cy.contains("I'm an accordion, click me!").click();
+  cy.get('details').should('not.have.attr', 'open');
 });

--- a/packages/cypress/tests/cypress/e2e/manual-snapshots.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/manual-snapshots.cy.ts
@@ -1,0 +1,5 @@
+it('Assets / query params determine which asset is served', () => {
+  cy.visit('/manual-snapshots');
+  cy.takeChromaticArchive();
+  cy.contains("I'm an accordion, click me!").click();
+});

--- a/packages/cypress/tests/cypress/e2e/manual-snapshots.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/manual-snapshots.cy.ts
@@ -1,6 +1,6 @@
 it('Manual Snapshots / multiple snapshots are taken', () => {
   cy.visit('/manual-snapshots');
-  cy.takeChromaticArchive();
+  cy.takeSnapshot();
   cy.contains("I'm an accordion, click me!").click();
   cy.contains('I am hiding inside!').should('be.visible');
 });

--- a/packages/cypress/tests/cypress/e2e/manual-snapshots.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/manual-snapshots.cy.ts
@@ -1,5 +1,6 @@
 it('Manual Snapshots / multiple snapshots are taken', () => {
   cy.visit('/manual-snapshots');
+  cy.takeChromaticArchive();
   cy.contains("I'm an accordion, click me!").click();
   cy.contains('I am hiding inside!').should('be.visible');
 });

--- a/packages/playwright/tests/manual-snapshots.spec.ts
+++ b/packages/playwright/tests/manual-snapshots.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, takeSnapshot } from '../src';
 
 test('Manual snapshots / multiple snapshots are taken', async ({ page }, testInfo) => {
   await page.goto('/manual-snapshots');
-  await takeSnapshot(page, testInfo);
+  await takeSnapshot(page, 'accordion expanded', testInfo);
   await page.locator('summary').click();
   await expect(page.getByText('I am hiding inside!')).toBeVisible();
 });

--- a/packages/playwright/tests/manual-snapshots.spec.ts
+++ b/packages/playwright/tests/manual-snapshots.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '../src';
+import { test, expect } from '../src';
 
 test('Manual snapshots / multiple snapshots are taken', async ({ page }) => {
   await page.goto('/manual-snapshots');

--- a/packages/playwright/tests/manual-snapshots.spec.ts
+++ b/packages/playwright/tests/manual-snapshots.spec.ts
@@ -1,0 +1,7 @@
+import { test } from '../src';
+
+test('Manual snapshots / multiple snapshots are taken', async ({ page }) => {
+  await page.goto('/manual-snapshots');
+  await page.locator('summary').click();
+  await expect(page.getByText('I am hiding inside!')).toBeVisible();
+});

--- a/packages/playwright/tests/manual-snapshots.spec.ts
+++ b/packages/playwright/tests/manual-snapshots.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, takeSnapshot } from '../src';
 
 test('Manual snapshots / multiple snapshots are taken', async ({ page }, testInfo) => {
   await page.goto('/manual-snapshots');
-  await takeSnapshot(page, 'accordion expanded', testInfo);
+  await takeSnapshot(page, 'accordion collapsed', testInfo);
   await page.locator('summary').click();
   await expect(page.getByText('I am hiding inside!')).toBeVisible();
 });

--- a/packages/playwright/tests/manual-snapshots.spec.ts
+++ b/packages/playwright/tests/manual-snapshots.spec.ts
@@ -1,7 +1,8 @@
-import { test, expect } from '../src';
+import { test, expect, takeSnapshot } from '../src';
 
-test('Manual snapshots / multiple snapshots are taken', async ({ page }) => {
+test('Manual snapshots / multiple snapshots are taken', async ({ page }, testInfo) => {
   await page.goto('/manual-snapshots');
+  await takeSnapshot(page, testInfo);
   await page.locator('summary').click();
   await expect(page.getByText('I am hiding inside!')).toBeVisible();
 });

--- a/test-server/fixtures/manual-snapshots.html
+++ b/test-server/fixtures/manual-snapshots.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>    
+    <head>
+      <style>
+        summary {
+          font-size: 22px;
+        }
+
+        p {
+          padding-inline-start: 32px;
+        }
+      </style>
+    </head>
+    <body>
+        <details>
+          <summary>I'm an accordion, click me!</summary>
+          <p>I am hiding inside!</p>
+        </details>
+    </body>
+</html>

--- a/test-server/server.js
+++ b/test-server/server.js
@@ -80,6 +80,10 @@ app.get('/form-success', (req, res) => {
   res.send(`${htmlIntro}<body><p>OK!</p></body>${htmlOutro}`);
 });
 
+app.get('/manual-snapshots', (req, res) => {
+  res.sendFile(path.join(__dirname, 'fixtures/manual-snapshots.html'));
+});
+
 app.listen(port, () => {
   console.log(`Example app listening on port ${port}`);
 });


### PR DESCRIPTION
Issue: #AP-4059

## What Changed

<!-- Insert a description below. -->
Manual snapshots in Cypress are now done with `cy.takeSnapshot()` to be consistent with changes to the manual snapshot API for Playwright (formerly it was `cy.takeChromaticArchive()`.

Also added the ability to supply a name for the manual snapshot (`cy.takeSnapshot({ name: 'some-great-name' })`), which gives Cypress feature parity with Playwright in terms of manual snapshots.

Added a visual test for manual snapshots for both Playwright and Cypress.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
* Go to UI Tests for the Cypress package
* For the "Multiple snapshots" tests, verify that one (manual snapshot) has a custom name (`accordion collapsed`), one (manual snapshot) has autogenerated name (`snapshot #2`), and the last (automatic) snapshot has an autogenerated name (`snapshot #3`).

- [x] Author QA
