### PR TITLE
Cypress: Electron can be used in interactive mode

### DIFF
--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -127,8 +127,13 @@ export const onBeforeBrowserLaunch = (
   // we don't use the browser parameter but we're keeping it here in case we'd ever need to read from it
   // (this way users wouldn't have to change their cypress.config file as it's already passed to us)
   browser: Cypress.Browser,
-  launchOptions: Cypress.BeforeBrowserLaunchOptions
+  launchOptions: Cypress.BeforeBrowserLaunchOptions,
+  config: any
 ) => {
+  if (config.isInteractive) {
+    return;
+  }
+
   const hostArg = launchOptions.args.find((arg) => arg.startsWith('--remote-debugging-address='));
   host = hostArg ? hostArg.split('=')[1] : '127.0.0.1';
 
@@ -155,10 +160,13 @@ export const onBeforeBrowserLaunch = (
   return launchOptions;
 };
 
-export const installPlugin = (on: any) => {
+export const installPlugin = (on: any, config: any) => {
   // these events are run on the server (in Node)
   on('task', {
     prepareArchives,
   });
-  on('before:browser:launch', onBeforeBrowserLaunch);
+
+  on('before:browser:launch', (browser: any, launchOptions: any) => {
+    onBeforeBrowserLaunch(browser, launchOptions, config);
+  });
 };

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -128,8 +128,11 @@ export const onBeforeBrowserLaunch = (
   // (this way users wouldn't have to change their cypress.config file as it's already passed to us)
   browser: Cypress.Browser,
   launchOptions: Cypress.BeforeBrowserLaunchOptions,
-  config: any
+  config: Cypress.PluginConfigOptions
 ) => {
+  // when Cypress is in interactive mode, we won't be snapshotting.
+  // Thus we don't need them to pass the ELECTRON_EXTRA_LAUNCH_ARGS for this command,
+  // or set up CDP or anything like that
   if (config.isInteractive) {
     return;
   }
@@ -160,13 +163,16 @@ export const onBeforeBrowserLaunch = (
   return launchOptions;
 };
 
-export const installPlugin = (on: any, config: any) => {
+export const installPlugin = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) => {
   // these events are run on the server (in Node)
   on('task', {
     prepareArchives,
   });
 
-  on('before:browser:launch', (browser: any, launchOptions: any) => {
-    onBeforeBrowserLaunch(browser, launchOptions, config);
-  });
+  on(
+    'before:browser:launch',
+    (browser: Cypress.Browser, launchOptions: Cypress.BeforeBrowserLaunchOptions) => {
+      onBeforeBrowserLaunch(browser, launchOptions, config);
+    }
+  );
 };

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -134,7 +134,7 @@ export const onBeforeBrowserLaunch = (
   // Thus we don't need them to pass the ELECTRON_EXTRA_LAUNCH_ARGS for this command,
   // or set up CDP or anything like that
   if (config.isInteractive) {
-    return;
+    return launchOptions;
   }
 
   const hostArg = launchOptions.args.find((arg) => arg.startsWith('--remote-debugging-address='));

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -1,8 +1,15 @@
 import { snapshot } from 'rrweb-snapshot';
 import './commands';
 
+const shouldTakeSnapshot = () => {
+  return !Cypress.env('disableAutoSnapshot') && !Cypress.config('isInteractive');
+};
+
 // these client-side lifecycle hooks will be added to the user's Cypress suite
 beforeEach(() => {
+  if (!shouldTakeSnapshot()) {
+    return;
+  }
   // this "manualSnapshots" variable will be available before, during, and after the test,
   // then cleaned up before the next test is run
   // (see https://docs.cypress.io/guides/core-concepts/variables-and-aliases#Aliases)
@@ -14,7 +21,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  if (Cypress.env('disableAutoSnapshot')) {
+  if (!shouldTakeSnapshot()) {
     return;
   }
   // can we be sure this always fires after all the requests are back?

--- a/packages/cypress/tests/cypress.config.ts
+++ b/packages/cypress/tests/cypress.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:3000',
     setupNodeEvents(on, config) {
-      installPlugin(on);
+      installPlugin(on, config);
     },
   },
 });


### PR DESCRIPTION
Issue: #AP-4060

## What Changed

<!-- Insert a description below. -->
Resolves a bug where when running Cypress in interactive mode (`cypress open`) and using the Electron browser, the tests would not run at all.

Got around this by not expecting users to prepend their `cypress open` command with `ELECTRON_EXTRA_LAUNCH_ARGS` variable (like we require them to do for `cypress run`).

In interactive mode, we don't listen to CDP or take snapshots or write archives at all.

### API Change
Instead of only passing `on` to our `installPlugin` function, we require `config` to be passed as well (so we can know if they are in interactive mode on the server side of things).

So it's now:
```ts
import { defineConfig } from 'cypress';
import { installPlugin } from '../src';

export default defineConfig({
  e2e: {
    setupNodeEvents(on, config) {
      // `config` now supplied to `installPlugin`
      installPlugin(on, config);
    },
  },
});

```

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
* Run `yarn test:server`
* Run `yarn cypress open --project packages/cypress/tests` (to run the Cypress tests in interactive mode)
* Verify Electron boots up and displays the tests
* Click through the tests
* Verify there are no errors (CDP or otherwise) in browser or server consoles


- [x] Author QA
