### PR TITLE
Cypress: exports support file as well as index file

### DIFF
--- a/.changeset/silver-carrots-scream.md
+++ b/.changeset/silver-carrots-scream.md
@@ -1,0 +1,5 @@
+---
+'chromatic-cypress': patch
+---
+
+Support file included in dist

--- a/packages/cypress/tests/cypress.config.ts
+++ b/packages/cypress/tests/cypress.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'cypress';
-import { installPlugin } from '../src';
+import { installPlugin } from '../dist';
 
 export default defineConfig({
   // needed since we use common mock images between Cypress and Playwright

--- a/packages/cypress/tests/cypress/support/e2e.js
+++ b/packages/cypress/tests/cypress/support/e2e.js
@@ -15,7 +15,7 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands';
-import '../../../src/support';
+import '../../../dist/support';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/packages/cypress/tsup.config.ts
+++ b/packages/cypress/tsup.config.ts
@@ -18,7 +18,7 @@ export default defineConfig((options) => [
   // We want the cypress functions to be importable from both CJS or ESM files
   {
     ...common(options),
-    entry: ['src/index.ts'],
+    entry: ['src/index.ts', 'src/support.ts'],
     format: ['cjs', 'esm'],
     platform: 'node',
   },


### PR DESCRIPTION
## What Changed

<!-- Insert a description below. -->
Makes sure the `support.ts` file is built into `dist` folder, so it is there for clients to import it in their support file.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
* Install this cypress package version on a local Cypress project
* Setup Chromatic for Cypress
* Run `yarn cypress run` and then Chromatic
* Verify that things run without failing and that the snapshots show up in the Chromatic build

- [x] Author QA
