### PR TITLE
Revert "Cypress: Electron can be used in interactive mode"

### DIFF
--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -138,16 +138,8 @@ export const onBeforeBrowserLaunch = (
   // we don't use the browser parameter but we're keeping it here in case we'd ever need to read from it
   // (this way users wouldn't have to change their cypress.config file as it's already passed to us)
   browser: Cypress.Browser,
-  launchOptions: Cypress.BeforeBrowserLaunchOptions,
-  config: Cypress.PluginConfigOptions
+  launchOptions: Cypress.BeforeBrowserLaunchOptions
 ) => {
-  // when Cypress is in interactive mode, we won't be snapshotting.
-  // Thus we don't need them to pass the ELECTRON_EXTRA_LAUNCH_ARGS for this command,
-  // or set up CDP or anything like that
-  if (config.isInteractive) {
-    return launchOptions;
-  }
-
   const hostArg = launchOptions.args.find((arg) => arg.startsWith('--remote-debugging-address='));
   host = hostArg ? hostArg.split('=')[1] : '127.0.0.1';
 
@@ -174,16 +166,10 @@ export const onBeforeBrowserLaunch = (
   return launchOptions;
 };
 
-export const installPlugin = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) => {
+export const installPlugin = (on: any) => {
   // these events are run on the server (in Node)
   on('task', {
     prepareArchives,
   });
-
-  on(
-    'before:browser:launch',
-    (browser: Cypress.Browser, launchOptions: Cypress.BeforeBrowserLaunchOptions) => {
-      onBeforeBrowserLaunch(browser, launchOptions, config);
-    }
-  );
+  on('before:browser:launch', onBeforeBrowserLaunch);
 };

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -1,15 +1,8 @@
 import { snapshot } from 'rrweb-snapshot';
 import './commands';
 
-const shouldTakeSnapshot = () => {
-  return !Cypress.env('disableAutoSnapshot') && !Cypress.config('isInteractive');
-};
-
 // these client-side lifecycle hooks will be added to the user's Cypress suite
 beforeEach(() => {
-  if (!shouldTakeSnapshot()) {
-    return;
-  }
   // this "manualSnapshots" variable will be available before, during, and after the test,
   // then cleaned up before the next test is run
   // (see https://docs.cypress.io/guides/core-concepts/variables-and-aliases#Aliases)
@@ -21,7 +14,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  if (!shouldTakeSnapshot()) {
+  if (Cypress.env('disableAutoSnapshot')) {
     return;
   }
   // can we be sure this always fires after all the requests are back?

--- a/packages/cypress/tests/cypress.config.ts
+++ b/packages/cypress/tests/cypress.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:3000',
     setupNodeEvents(on, config) {
-      installPlugin(on, config);
+      installPlugin(on);
     },
   },
 });


### PR DESCRIPTION
Reverts chromaui/test-archiver#72.

Unfortunately, `config.isInteractive` (which I was using to disable archiving if the user is using `cypress open`) [mistakenly](https://github.com/cypress-io/cypress/issues/20789#issuecomment-1901519123) always returns `true`, even when it's not in interactive mode. This meant that we were _never_ archiving.

Reverting this so archiving works for `cypress run`.