### PR TITLE
Cypress: Detecting interactive mode, take 2

### DIFF
--- a/packages/cypress/src/commands.ts
+++ b/packages/cypress/src/commands.ts
@@ -3,7 +3,7 @@ import type { elementNode } from 'rrweb-snapshot';
 // @ts-expect-error will fix when Cypress has its own package
 Cypress.Commands.add('takeSnapshot', (name?: string) => {
   // don't take snapshots when running `cypress open`
-  if (Cypress.config('isTextTerminal')) {
+  if (!Cypress.config('isTextTerminal')) {
     return;
   }
 

--- a/packages/cypress/src/commands.ts
+++ b/packages/cypress/src/commands.ts
@@ -3,7 +3,7 @@ import type { elementNode } from 'rrweb-snapshot';
 // @ts-expect-error will fix when Cypress has its own package
 Cypress.Commands.add('takeSnapshot', (name?: string) => {
   // don't take snapshots when running `cypress open`
-  if (Cypress.config('isInteractive')) {
+  if (Cypress.config('isTextTerminal')) {
     return;
   }
 

--- a/packages/cypress/src/commands.ts
+++ b/packages/cypress/src/commands.ts
@@ -2,6 +2,11 @@ import { snapshot } from 'rrweb-snapshot';
 import type { elementNode } from 'rrweb-snapshot';
 // @ts-expect-error will fix when Cypress has its own package
 Cypress.Commands.add('takeSnapshot', (name?: string) => {
+  // don't take snapshots when running `cypress open`
+  if (Cypress.config('isInteractive')) {
+    return;
+  }
+
   cy.document().then((doc) => {
     // here, handle the source map
     const manualSnapshot = snapshot(doc);

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -138,8 +138,14 @@ export const onBeforeBrowserLaunch = (
   // we don't use the browser parameter but we're keeping it here in case we'd ever need to read from it
   // (this way users wouldn't have to change their cypress.config file as it's already passed to us)
   browser: Cypress.Browser,
-  launchOptions: Cypress.BeforeBrowserLaunchOptions
+  launchOptions: Cypress.BeforeBrowserLaunchOptions,
+  config: any
 ) => {
+  // don't take snapshots when running `cypress open`
+  if (!config.isTextTerminal) {
+    return launchOptions;
+  }
+
   const hostArg = launchOptions.args.find((arg) => arg.startsWith('--remote-debugging-address='));
   host = hostArg ? hostArg.split('=')[1] : '127.0.0.1';
 
@@ -166,10 +172,12 @@ export const onBeforeBrowserLaunch = (
   return launchOptions;
 };
 
-export const installPlugin = (on: any) => {
+export const installPlugin = (on: any, config: any) => {
   // these events are run on the server (in Node)
   on('task', {
     prepareArchives,
   });
-  on('before:browser:launch', onBeforeBrowserLaunch);
+  on('before:browser:launch', (browser: any, launchOptions: any) => {
+    onBeforeBrowserLaunch(browser, launchOptions, config);
+  });
 };

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -139,7 +139,7 @@ export const onBeforeBrowserLaunch = (
   // (this way users wouldn't have to change their cypress.config file as it's already passed to us)
   browser: Cypress.Browser,
   launchOptions: Cypress.BeforeBrowserLaunchOptions,
-  config: any
+  config: Cypress.PluginConfigOptions
 ) => {
   // don't take snapshots when running `cypress open`
   if (!config.isTextTerminal) {
@@ -172,12 +172,15 @@ export const onBeforeBrowserLaunch = (
   return launchOptions;
 };
 
-export const installPlugin = (on: any, config: any) => {
+export const installPlugin = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) => {
   // these events are run on the server (in Node)
   on('task', {
     prepareArchives,
   });
-  on('before:browser:launch', (browser: any, launchOptions: any) => {
-    onBeforeBrowserLaunch(browser, launchOptions, config);
-  });
+  on(
+    'before:browser:launch',
+    (browser: Cypress.Browser, launchOptions: Cypress.BeforeBrowserLaunchOptions) => {
+      onBeforeBrowserLaunch(browser, launchOptions, config);
+    }
+  );
 };

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -4,7 +4,7 @@ import './commands';
 // these client-side lifecycle hooks will be added to the user's Cypress suite
 beforeEach(() => {
   // don't take snapshots when running `cypress open`
-  if (Cypress.config('isInteractive')) {
+  if (Cypress.config('isTextTerminal')) {
     return;
   }
   // this "manualSnapshots" variable will be available before, during, and after the test,
@@ -19,7 +19,7 @@ beforeEach(() => {
 
 afterEach(() => {
   // don't take snapshots when running `cypress open`
-  if (Cypress.env('disableAutoSnapshot') || Cypress.config('isInteractive')) {
+  if (Cypress.env('disableAutoSnapshot') || Cypress.config('isTextTerminal')) {
     return;
   }
   // can we be sure this always fires after all the requests are back?

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -4,7 +4,7 @@ import './commands';
 // these client-side lifecycle hooks will be added to the user's Cypress suite
 beforeEach(() => {
   // don't take snapshots when running `cypress open`
-  if (Cypress.config('isTextTerminal')) {
+  if (!Cypress.config('isTextTerminal')) {
     return;
   }
   // this "manualSnapshots" variable will be available before, during, and after the test,
@@ -19,7 +19,7 @@ beforeEach(() => {
 
 afterEach(() => {
   // don't take snapshots when running `cypress open`
-  if (Cypress.env('disableAutoSnapshot') || Cypress.config('isTextTerminal')) {
+  if (Cypress.env('disableAutoSnapshot') || !Cypress.config('isTextTerminal')) {
     return;
   }
   // can we be sure this always fires after all the requests are back?

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -3,6 +3,10 @@ import './commands';
 
 // these client-side lifecycle hooks will be added to the user's Cypress suite
 beforeEach(() => {
+  // don't take snapshots when running `cypress open`
+  if (Cypress.config('isInteractive')) {
+    return;
+  }
   // this "manualSnapshots" variable will be available before, during, and after the test,
   // then cleaned up before the next test is run
   // (see https://docs.cypress.io/guides/core-concepts/variables-and-aliases#Aliases)
@@ -14,7 +18,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  if (Cypress.env('disableAutoSnapshot')) {
+  // don't take snapshots when running `cypress open`
+  if (Cypress.env('disableAutoSnapshot') || Cypress.config('isInteractive')) {
     return;
   }
   // can we be sure this always fires after all the requests are back?

--- a/packages/cypress/tests/cypress.config.ts
+++ b/packages/cypress/tests/cypress.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:3000',
     setupNodeEvents(on, config) {
-      installPlugin(on);
+      installPlugin(on, config);
     },
   },
 });


### PR DESCRIPTION
Issue: #AP-4060

## What Changed

<!-- Insert a description below. -->
Differentiates between Cypress' "run mode" (used for CI) and "interactive mode" (used for interactively clicking through tests and seeing the DOM), via `config.isTextTerminal`. This is so we don't need users to prepend their `cypress open` command with the `ELECTRON_EXTRA_LAUNCH_ARGS` env variable, and also makes it so we won't archive in interactive mode.

Previously I had tried doing this through [`config.isInteractive`](https://docs.cypress.io/guides/references/configuration#isInteractive) in #72, but due to a Cypress [bug](https://github.com/cypress-io/cypress/issues/20789) that value wasn't getting the correct values in all cases.

Note that `config.isTextTerminal` is undocumented. However, it's the way users in the bug ticket [recommended](https://github.com/cypress-io/cypress/issues/20789) to do, and more importantly, it's how Cypress appears to be telling things whether to be in "run mode" or "interactive mode" [in their tests](https://github.com/cypress-io/cypress/blob/152b3555b86d542b2b5a7ad5b1de2ab520b9ea56/npm/vite-dev-server/test/resolveConfig.spec.ts#L84-L98), so we should be pretty safe.

### API Change
This requires Cypress users to now pass `config` to `installPlugin`, as follows:
```
// cypress.config.ts|js file
export default defineConfig({
  e2e: {
    setupNodeEvents(on, config) {
      // previously was just `installPlugin(on)`
      installPlugin(on, config);
    },
  },
});

```

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->

**Cypress run command:**
* View the GitHub Action logs where `yarn test:cypress` is run
* Verify that there are no console errors or other odd behavior, and that the tests all passed

**Chromatic build:**
* View the test results from the `UI Tests: Cypress` Chromatic build
* Verify the stories are all snapshotted as expected and all are included (including manual snapshots)

**Cypress, interactive mode:**
* Locally, check out this branch and run `yarn`
* Locally, blow away contents of `packages/cypress/tests/downloads` folder (to ensure no hold-over archives are there)
* Locally, run `yarn test:server`
* Locally, run `yarn cypress open --project packages/cypress/tests`
* Click through all the tests (for Electron and Chrome)
* Verify that the server console doesn't print any errors (CDP or otherwise)
* Verify that all the tests pass
* Verify that even the manual-snapshotted tests run
* Verify that the `packages/cypress/tests/downloads` folder is still empty


- [x] Author QA
