### PR TITLE
Export the archive storybook scripts

### DIFF
--- a/.changeset/few-masks-rush.md
+++ b/.changeset/few-masks-rush.md
@@ -1,0 +1,6 @@
+---
+'chromatic-playwright': minor
+'chromatic-cypress': minor
+---
+
+add exports for the archive storybook scripts so that they can be invoked from the CLI

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -23,6 +23,8 @@
       "import": "./dist/support.mjs",
       "require": "./dist/support.js"
     },
+    "./bin/archive-storybook": "./dist/bin/archive-storybook.js",
+    "./bin/build-archive-storybook": "./dist/bin/build-archive-storybook.js",
     "./package.json": "./package.json"
   },
   "bin": {

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -18,6 +18,8 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
+    "./bin/archive-storybook": "./dist/bin/archive-storybook.js",
+    "./bin/build-archive-storybook": "./dist/bin/build-archive-storybook.js",
     "./package.json": "./package.json"
   },
   "bin": {


### PR DESCRIPTION
Issue: #

## What Changed

<!-- Insert a description below. -->
Exports the archive storybook scripts so that they can be invoked from the CLI.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
Try this canary out with the new CLI canary.
